### PR TITLE
182: Removing unwanted default value for list option to safe command

### DIFF
--- a/app/sentinel/cmd/main.go
+++ b/app/sentinel/cmd/main.go
@@ -20,7 +20,7 @@ import (
 
 func parseList(parser *argparse.Parser) *bool {
 	return parser.Flag("l", "list", &argparse.Options{
-		Required: false, Default: false, Help: "lists all registered workloads.",
+		Required: false, Help: "lists all registered workloads.",
 	})
 }
 


### PR DESCRIPTION
Removing unwanted default value for list option to safe command.
Sample help output for safe command:
`k exec -it -n vsecm-system vsecm-sentinel-787bb957c6-mpxw5 -- safe -h`

> usage: safe [-h|--help] [-l|--list] [-k|--use-k8s] [-d|--delete] [-a|--append]
>             [-n|--namespace "<value>"] [-i|--input-keys "<value>"] [-b|--store
>             "<value>"] [-w|--workload "<value>"] [-s|--secret "<value>"]
>             [-t|--template "<value>"] [-f|--format "<value>"] [-e|--encrypt]
> 
> Assigns secrets to workloads.
> 
> Arguments:
> 
>   -h  --help        Print help information
>   -l  --list        lists all registered workloads.
>   -k  --use-k8s     update an associated Kubernetes secret upon save. Overrides
>                     VSECM_SAFE_USE_KUBERNETES_SECRETS.. Default: false
>   -d  --delete      delete the secret associated with the workload.. Default:
>                     false
>   -a  --append      append the secret to the existing secret collection
>                     associated with the workload.. Default: false
>   -n  --namespace   the namespace of the Kubernetes Secret to create.. Default:
>                     default
>   -i  --input-keys  A string containing the private and public Age keys and AES
>                     seed, each separated by '\n'.
>   -b  --store       backing store type (file|memory) (default: file). Overrides
>                     VSECM_SAFE_BACKING_STORE.
>   -w  --workload    name of the workload (i.e. the '$name' segment of its
>                     ClusterSPIFFEID
>                     ('spiffe://trustDomain/workload/$name/…')).
>   -s  --secret      the secret to store for the workload.
>   -t  --template    the template used to transform the secret stored.
>   -f  --format      the format to display the secrets in. Has effect only when
>                     `-t` is provided. Valid values: yaml, json, and none.
>                     Defaults to none.
>   -e  --encrypt     returns an encrypted version of the secret if used with
>                     `-s`; decrypts the secret before registering it to the
>                     workload if used with `-s` and `-w`.. Default: false