### PR TITLE
Remove podAnnotations value to fix local deploy

### DIFF
--- a/helm-charts/0.21.5/templates/hook-preinstall-namespace.yaml
+++ b/helm-charts/0.21.5/templates/hook-preinstall-namespace.yaml
@@ -12,8 +12,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.global.vsecm.namespace }}
-  {{- with .Values.podAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
     "helm.sh/hook-weight": "1"
-  {{- end }}

--- a/helm-charts/0.21.5/values.yaml
+++ b/helm-charts/0.21.5/values.yaml
@@ -57,8 +57,6 @@ global:
     serverPort: 8081
 
 
-podAnnotations:
-  "helm.sh/hook": pre-install
 
 replicaCount: 1
 

--- a/helm-charts/0.21.6/templates/hook-preinstall-namespace.yaml
+++ b/helm-charts/0.21.6/templates/hook-preinstall-namespace.yaml
@@ -12,8 +12,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.global.vsecm.namespace }}
-  {{- with .Values.podAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
     "helm.sh/hook-weight": "1"
-  {{- end }}

--- a/helm-charts/0.21.6/values.yaml
+++ b/helm-charts/0.21.6/values.yaml
@@ -61,5 +61,4 @@ global:
     logLevel: DEBUG
     serverPort: 8081
 
-podAnnotations:
-  "helm.sh/hook": pre-install
+

--- a/k8s/0.21.5/0.21.5-local-distroless-fips.yaml
+++ b/k8s/0.21.5/0.21.5-local-distroless-fips.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -883,7 +901,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "localhost:5000/vsecm-ist-safe:0.21.5"
+          image: "localhost:5000/vsecm-ist-fips-safe:0.21.5"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -914,9 +932,9 @@ spec:
               value: "spiffe://vsecm.com/workload/"
             - name: VSECM_SAFE_DATA_PATH
               value: "/data"
-            - name: VSECM_CRYPTO_KEY_NAME
+            - name: VSECM_SAFE_CRYPTO_KEY_NAME
               value: "vsecm-safe-age-key"
-            - name: VSECM_CRYPTO_KEY_PATH
+            - name: VSECM_SAFE_CRYPTO_KEY_PATH
               value: "/key/key.txt"
             - name: VSECM_SAFE_MANUAL_KEY_INPUT
               value: "false"
@@ -1026,7 +1044,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "localhost:5000/vsecm-ist-sentinel:0.21.5"
+          image: "localhost:5000/vsecm-ist-fips-sentinel:0.21.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: spire-agent-socket
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.5/0.21.5-local-distroless.yaml
+++ b/k8s/0.21.5/0.21.5-local-distroless.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -914,9 +932,9 @@ spec:
               value: "spiffe://vsecm.com/workload/"
             - name: VSECM_SAFE_DATA_PATH
               value: "/data"
-            - name: VSECM_CRYPTO_KEY_NAME
+            - name: VSECM_SAFE_CRYPTO_KEY_NAME
               value: "vsecm-safe-age-key"
-            - name: VSECM_CRYPTO_KEY_PATH
+            - name: VSECM_SAFE_CRYPTO_KEY_PATH
               value: "/key/key.txt"
             - name: VSECM_SAFE_MANUAL_KEY_INPUT
               value: "false"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.5/0.21.5-local-photon-fips.yaml
+++ b/k8s/0.21.5/0.21.5-local-photon-fips.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -914,9 +932,9 @@ spec:
               value: "spiffe://vsecm.com/workload/"
             - name: VSECM_SAFE_DATA_PATH
               value: "/data"
-            - name: VSECM_CRYPTO_KEY_NAME
+            - name: VSECM_SAFE_CRYPTO_KEY_NAME
               value: "vsecm-safe-age-key"
-            - name: VSECM_CRYPTO_KEY_PATH
+            - name: VSECM_SAFE_CRYPTO_KEY_PATH
               value: "/key/key.txt"
             - name: VSECM_SAFE_MANUAL_KEY_INPUT
               value: "false"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.5/0.21.5-local-photon.yaml
+++ b/k8s/0.21.5/0.21.5-local-photon.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -883,7 +901,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "localhost:5000/vsecm-ist-safe:0.21.5"
+          image: "localhost:5000/vsecm-photon-safe:0.21.5"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -914,9 +932,9 @@ spec:
               value: "spiffe://vsecm.com/workload/"
             - name: VSECM_SAFE_DATA_PATH
               value: "/data"
-            - name: VSECM_CRYPTO_KEY_NAME
+            - name: VSECM_SAFE_CRYPTO_KEY_NAME
               value: "vsecm-safe-age-key"
-            - name: VSECM_CRYPTO_KEY_PATH
+            - name: VSECM_SAFE_CRYPTO_KEY_PATH
               value: "/key/key.txt"
             - name: VSECM_SAFE_MANUAL_KEY_INPUT
               value: "false"
@@ -1026,7 +1044,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "localhost:5000/vsecm-ist-sentinel:0.21.5"
+          image: "localhost:5000/vsecm-photon-sentinel:0.21.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: spire-agent-socket
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.5/0.21.5-remote-distroless-fips.yaml
+++ b/k8s/0.21.5/0.21.5-remote-distroless-fips.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -883,7 +901,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-safe:0.21.5"
+          image: "vsecm/vsecm-ist-fips-safe:0.21.5"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -914,9 +932,9 @@ spec:
               value: "spiffe://vsecm.com/workload/"
             - name: VSECM_SAFE_DATA_PATH
               value: "/data"
-            - name: VSECM_CRYPTO_KEY_NAME
+            - name: VSECM_SAFE_CRYPTO_KEY_NAME
               value: "vsecm-safe-age-key"
-            - name: VSECM_CRYPTO_KEY_PATH
+            - name: VSECM_SAFE_CRYPTO_KEY_PATH
               value: "/key/key.txt"
             - name: VSECM_SAFE_MANUAL_KEY_INPUT
               value: "false"
@@ -1026,7 +1044,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-sentinel:0.21.5"
+          image: "vsecm/vsecm-ist-fips-sentinel:0.21.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: spire-agent-socket
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.5/0.21.5-remote-distroless.yaml
+++ b/k8s/0.21.5/0.21.5-remote-distroless.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -914,9 +932,9 @@ spec:
               value: "spiffe://vsecm.com/workload/"
             - name: VSECM_SAFE_DATA_PATH
               value: "/data"
-            - name: VSECM_CRYPTO_KEY_NAME
+            - name: VSECM_SAFE_CRYPTO_KEY_NAME
               value: "vsecm-safe-age-key"
-            - name: VSECM_CRYPTO_KEY_PATH
+            - name: VSECM_SAFE_CRYPTO_KEY_PATH
               value: "/key/key.txt"
             - name: VSECM_SAFE_MANUAL_KEY_INPUT
               value: "false"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.5/0.21.5-remote-photon-fips.yaml
+++ b/k8s/0.21.5/0.21.5-remote-photon-fips.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -914,9 +932,9 @@ spec:
               value: "spiffe://vsecm.com/workload/"
             - name: VSECM_SAFE_DATA_PATH
               value: "/data"
-            - name: VSECM_CRYPTO_KEY_NAME
+            - name: VSECM_SAFE_CRYPTO_KEY_NAME
               value: "vsecm-safe-age-key"
-            - name: VSECM_CRYPTO_KEY_PATH
+            - name: VSECM_SAFE_CRYPTO_KEY_PATH
               value: "/key/key.txt"
             - name: VSECM_SAFE_MANUAL_KEY_INPUT
               value: "false"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.5/0.21.5-remote-photon.yaml
+++ b/k8s/0.21.5/0.21.5-remote-photon.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -883,7 +901,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-safe:0.21.5"
+          image: "vsecm/vsecm-photon-safe:0.21.5"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -914,9 +932,9 @@ spec:
               value: "spiffe://vsecm.com/workload/"
             - name: VSECM_SAFE_DATA_PATH
               value: "/data"
-            - name: VSECM_CRYPTO_KEY_NAME
+            - name: VSECM_SAFE_CRYPTO_KEY_NAME
               value: "vsecm-safe-age-key"
-            - name: VSECM_CRYPTO_KEY_PATH
+            - name: VSECM_SAFE_CRYPTO_KEY_PATH
               value: "/key/key.txt"
             - name: VSECM_SAFE_MANUAL_KEY_INPUT
               value: "false"
@@ -1026,7 +1044,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-sentinel:0.21.5"
+          image: "vsecm/vsecm-photon-sentinel:0.21.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: spire-agent-socket
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.5/crds/spire.spiffe.io_clusterfederatedtrustdomains.yaml
+++ b/k8s/0.21.5/crds/spire.spiffe.io_clusterfederatedtrustdomains.yaml
@@ -1,3 +1,12 @@
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/k8s/0.21.5/crds/spire.spiffe.io_clusterspiffeids.yaml
+++ b/k8s/0.21.5/crds/spire.spiffe.io_clusterspiffeids.yaml
@@ -1,3 +1,12 @@
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/k8s/0.21.5/crds/spire.spiffe.io_clusterstaticentries.yaml
+++ b/k8s/0.21.5/crds/spire.spiffe.io_clusterstaticentries.yaml
@@ -1,3 +1,12 @@
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/k8s/0.21.5/crds/spire.spiffe.io_controllermanagerconfigs.yaml
+++ b/k8s/0.21.5/crds/spire.spiffe.io_controllermanagerconfigs.yaml
@@ -1,3 +1,12 @@
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/k8s/0.21.6/0.21.6-local-distroless-fips.yaml
+++ b/k8s/0.21.6/0.21.6-local-distroless-fips.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -33,8 +51,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -58,8 +76,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -638,12 +656,12 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -655,8 +673,8 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
 ---
 # Source: vsecm/charts/spire/templates/spire-server.yaml
@@ -855,12 +873,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -868,14 +886,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-safe
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-safe
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-safe
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-safe
@@ -883,7 +901,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-safe:0.21.5"
+          image: "localhost:5000/vsecm-ist-fips-safe:0.21.5"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -998,12 +1016,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -1011,14 +1029,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-sentinel
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-sentinel
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-sentinel
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-sentinel
@@ -1026,7 +1044,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-sentinel:0.21.5"
+          image: "localhost:5000/vsecm-ist-fips-sentinel:0.21.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: spire-agent-socket
@@ -1173,16 +1191,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-safe\
+    /workload/vsecm-safe\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
+      app.kubernetes.io/name: vsecm-safe
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1202,16 +1220,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-sentinel\
+    /workload/vsecm-sentinel\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
+      app.kubernetes.io/name: vsecm-sentinel
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.6/0.21.6-local-distroless.yaml
+++ b/k8s/0.21.6/0.21.6-local-distroless.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -33,8 +51,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -58,8 +76,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -638,12 +656,12 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -655,8 +673,8 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
 ---
 # Source: vsecm/charts/spire/templates/spire-server.yaml
@@ -855,12 +873,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -868,14 +886,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-safe
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-safe
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-safe
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-safe
@@ -883,7 +901,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-safe:0.21.5"
+          image: "localhost:5000/vsecm-ist-safe:0.21.5"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -998,12 +1016,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -1011,14 +1029,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-sentinel
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-sentinel
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-sentinel
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-sentinel
@@ -1026,7 +1044,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-sentinel:0.21.5"
+          image: "localhost:5000/vsecm-ist-sentinel:0.21.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: spire-agent-socket
@@ -1173,16 +1191,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-safe\
+    /workload/vsecm-safe\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
+      app.kubernetes.io/name: vsecm-safe
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1202,16 +1220,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-sentinel\
+    /workload/vsecm-sentinel\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
+      app.kubernetes.io/name: vsecm-sentinel
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.6/0.21.6-local-photon-fips.yaml
+++ b/k8s/0.21.6/0.21.6-local-photon-fips.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -33,8 +51,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -58,8 +76,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -638,12 +656,12 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -655,8 +673,8 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
 ---
 # Source: vsecm/charts/spire/templates/spire-server.yaml
@@ -855,12 +873,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -868,14 +886,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-safe
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-safe
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-safe
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-safe
@@ -883,7 +901,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-safe:0.21.5"
+          image: "localhost:5000/vsecm-ist-safe:0.21.5"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -998,12 +1016,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -1011,14 +1029,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-sentinel
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-sentinel
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-sentinel
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-sentinel
@@ -1026,7 +1044,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-sentinel:0.21.5"
+          image: "localhost:5000/vsecm-ist-sentinel:0.21.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: spire-agent-socket
@@ -1173,16 +1191,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-safe\
+    /workload/vsecm-safe\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
+      app.kubernetes.io/name: vsecm-safe
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1202,16 +1220,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-sentinel\
+    /workload/vsecm-sentinel\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
+      app.kubernetes.io/name: vsecm-sentinel
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.6/0.21.6-local-photon.yaml
+++ b/k8s/0.21.6/0.21.6-local-photon.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -33,8 +51,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -58,8 +76,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -638,12 +656,12 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -655,8 +673,8 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
 ---
 # Source: vsecm/charts/spire/templates/spire-server.yaml
@@ -855,12 +873,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -868,14 +886,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-safe
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-safe
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-safe
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-safe
@@ -883,7 +901,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-safe:0.21.5"
+          image: "localhost:5000/vsecm-photon-safe:0.21.5"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -998,12 +1016,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -1011,14 +1029,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-sentinel
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-sentinel
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-sentinel
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-sentinel
@@ -1026,7 +1044,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-sentinel:0.21.5"
+          image: "localhost:5000/vsecm-photon-sentinel:0.21.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: spire-agent-socket
@@ -1173,16 +1191,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-safe\
+    /workload/vsecm-safe\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
+      app.kubernetes.io/name: vsecm-safe
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1202,16 +1220,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-sentinel\
+    /workload/vsecm-sentinel\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
+      app.kubernetes.io/name: vsecm-sentinel
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.6/0.21.6-remote-distroless-fips.yaml
+++ b/k8s/0.21.6/0.21.6-remote-distroless-fips.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -33,8 +51,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -58,8 +76,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -638,12 +656,12 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -655,8 +673,8 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
 ---
 # Source: vsecm/charts/spire/templates/spire-server.yaml
@@ -855,12 +873,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -868,14 +886,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-safe
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-safe
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-safe
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-safe
@@ -883,7 +901,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-safe:0.21.5"
+          image: "vsecm/vsecm-ist-fips-safe:0.21.5"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -998,12 +1016,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -1011,14 +1029,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-sentinel
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-sentinel
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-sentinel
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-sentinel
@@ -1026,7 +1044,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-sentinel:0.21.5"
+          image: "vsecm/vsecm-ist-fips-sentinel:0.21.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: spire-agent-socket
@@ -1173,16 +1191,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-safe\
+    /workload/vsecm-safe\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
+      app.kubernetes.io/name: vsecm-safe
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1202,16 +1220,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-sentinel\
+    /workload/vsecm-sentinel\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
+      app.kubernetes.io/name: vsecm-sentinel
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.6/0.21.6-remote-distroless.yaml
+++ b/k8s/0.21.6/0.21.6-remote-distroless.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -33,8 +51,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -58,8 +76,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -638,12 +656,12 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -655,8 +673,8 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
 ---
 # Source: vsecm/charts/spire/templates/spire-server.yaml
@@ -855,12 +873,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -868,14 +886,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-safe
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-safe
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-safe
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-safe
@@ -998,12 +1016,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -1011,14 +1029,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-sentinel
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-sentinel
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-sentinel
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-sentinel
@@ -1173,16 +1191,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-safe\
+    /workload/vsecm-safe\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
+      app.kubernetes.io/name: vsecm-safe
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1202,16 +1220,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-sentinel\
+    /workload/vsecm-sentinel\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
+      app.kubernetes.io/name: vsecm-sentinel
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.6/0.21.6-remote-photon-fips.yaml
+++ b/k8s/0.21.6/0.21.6-remote-photon-fips.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -33,8 +51,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -58,8 +76,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -638,12 +656,12 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -655,8 +673,8 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
 ---
 # Source: vsecm/charts/spire/templates/spire-server.yaml
@@ -855,12 +873,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -868,14 +886,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-safe
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-safe
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-safe
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-safe
@@ -998,12 +1016,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -1011,14 +1029,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-sentinel
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-sentinel
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-sentinel
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-sentinel
@@ -1173,16 +1191,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-safe\
+    /workload/vsecm-safe\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
+      app.kubernetes.io/name: vsecm-safe
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1202,16 +1220,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-sentinel\
+    /workload/vsecm-sentinel\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
+      app.kubernetes.io/name: vsecm-sentinel
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"

--- a/k8s/0.21.6/0.21.6-remote-photon.yaml
+++ b/k8s/0.21.6/0.21.6-remote-photon.yaml
@@ -15,6 +15,24 @@ kind: Namespace
 metadata:
   name: spire-system
 ---
+# Source: vsecm/templates/hook-preinstall-namespace.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets… secret
+# >/
+# <>/' Copyright 2023–present VMware, Inc.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vsecm-system
+  annotations:
+    "helm.sh/hook-weight": "1"
+---
 # Source: vsecm/charts/safe/templates/serviceaccount.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -33,8 +51,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -58,8 +76,8 @@ metadata:
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -638,12 +656,12 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -655,8 +673,8 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
 ---
 # Source: vsecm/charts/spire/templates/spire-server.yaml
@@ -855,12 +873,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
   namespace: vsecm-system
   labels:
     helm.sh/chart: safe-0.21.6
-    app.kubernetes.io/name: release-name-safe
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-safe
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -868,14 +886,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-safe
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-safe
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-safe
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-safe
@@ -883,7 +901,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-safe:0.21.5"
+          image: "vsecm/vsecm-photon-safe:0.21.5"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
@@ -998,12 +1016,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
   namespace: vsecm-system
   labels:
     helm.sh/chart: sentinel-0.21.6
-    app.kubernetes.io/name: release-name-sentinel
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/name: vsecm-sentinel
+    app.kubernetes.io/instance: vsecm
     app.kubernetes.io/part-of: vsecm-system
     app.kubernetes.io/version: "0.21.6"
     app.kubernetes.io/managed-by: Helm
@@ -1011,14 +1029,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/name: vsecm-sentinel
+      app.kubernetes.io/instance: vsecm
       app.kubernetes.io/part-of: vsecm-system
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: release-name-sentinel
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/name: vsecm-sentinel
+        app.kubernetes.io/instance: vsecm
         app.kubernetes.io/part-of: vsecm-system
     spec:
       serviceAccountName: vsecm-sentinel
@@ -1026,7 +1044,7 @@ spec:
         {}
       containers:
         - name: main
-          image: "vsecm/vsecm-ist-sentinel:0.21.5"
+          image: "vsecm/vsecm-photon-sentinel:0.21.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: spire-agent-socket
@@ -1173,16 +1191,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-safe
+  name: vsecm-safe
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-safe\
+    /workload/vsecm-safe\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-safe
+      app.kubernetes.io/name: vsecm-safe
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1202,16 +1220,16 @@ spec:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: release-name-sentinel
+  name: vsecm-sentinel
 spec:
   spiffeIDTemplate: "spiffe://vsecm.com\
-    /workload/release-name-sentinel\
+    /workload/vsecm-sentinel\
     /ns/{{ .PodMeta.Namespace }}\
     /sa/{{ .PodSpec.ServiceAccountName }}\
     /n/{{ .PodMeta.Name }}"
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: release-name-sentinel
+      app.kubernetes.io/name: vsecm-sentinel
       app.kubernetes.io/part-of: vsecm-system
   workloadSelectorTemplates:
     - "k8s:ns:vsecm-system"
@@ -1275,22 +1293,3 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["clusterstaticentries"]
     sideEffects: None
----
-# Source: vsecm/templates/hook-preinstall-namespace.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets… secret
-# >/
-# <>/' Copyright 2023–present VMware, Inc.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vsecm-system
-  annotations:
-    helm.sh/hook: pre-install
-    "helm.sh/hook-weight": "1"


### PR DESCRIPTION


This PR removes the `podAnnotations` from Helm Charts 0.21.5 and 0.21.6 and updates manifests. 

The `podAnnotations` in the values yaml caused the` vsecm-system` namespace resource to be placed at the bottom of the manifests, which resulted in the resources not finding the namespace because the order changed when deploying with Kubernetes. 

The previous helm-chart versions don't have this problem because the `podAnnotations` is duplicated on them and I guess the empty value was overriding the value used in condition.

I'm not entirely familiar with Kubernetes and Helm, but I've read that Helm handles the creation of fundamental resources. I am uncertain if we need this hook-weight annotation, also the spire-system namespace resource doesn't have it. But I still added that annotation to the preinstall hook. 

I can update the PR with your feedback, I don't know whether I need to create a new helm chart or generate the manifests in another PR.

