### PR TITLE
Upgrade Spire Controller Manager to 0.4.0 & add required permission to manager-role

### DIFF
--- a/helm-charts/0.21.6/charts/spire/templates/crd-rbac/hook-preinstall_role.yaml
+++ b/helm-charts/0.21.6/charts/spire/templates/crd-rbac/hook-preinstall_role.yaml
@@ -13,6 +13,9 @@ kind: ClusterRole
 metadata:
   name: manager-role
 rules:
+  - apiGroups: [ "" ]
+    resources: [ "endpoints" ]
+    verbs: [ "get", "list", "watch" ]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]

--- a/helm-charts/0.21.6/values.yaml
+++ b/helm-charts/0.21.6/values.yaml
@@ -47,7 +47,7 @@ global:
       pullPolicy: IfNotPresent
     spireControllerManager:
       repository: ghcr.io/spiffe/spire-controller-manager
-      tag: 0.3.0
+      tag: 0.4.0
       pullPolicy: IfNotPresent
   vsecm:
     namespace: vsecm-system

--- a/k8s/0.21.6/spire.yaml
+++ b/k8s/0.21.6/spire.yaml
@@ -221,6 +221,9 @@ kind: ClusterRole
 metadata:
   name: manager-role
 rules:
+  - apiGroups: [ "" ]
+    resources: [ "endpoints" ]
+    verbs: [ "get", "list", "watch" ]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]
@@ -649,7 +652,7 @@ spec:
             - name: spire-server-socket
               mountPath: /tmp/spire-server/private
         - name: spire-controller-manager
-          image: ghcr.io/spiffe/spire-controller-manager:0.3.0
+          image: ghcr.io/spiffe/spire-controller-manager:0.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9443


### PR DESCRIPTION
This PR should fix #365. I updated the controller manager and noticed these errors in the controller manager logs.
Then I checked the spire-controller-manager repo and I noticed that there were new roles that needed to be added to manager-role 

- upgrade spire controller manager to 0.4.0
- add get, list and watch endpoints permission to spire cluster role


https://github.com/spiffe/spire-controller-manager/blob/v0.4.0/config/rbac/role.yaml#L11

<img width="2132" alt="image" src="https://github.com/vmware-tanzu/secrets-manager/assets/47208861/58a423e7-7206-488b-b42a-1ee9932a27dc">
