### PR TITLE
Sentinel to display secret values in encrpted form

### DIFF
--- a/app/safe/internal/server/handle/handle.go
+++ b/app/safe/internal/server/handle/handle.go
@@ -79,6 +79,12 @@ func InitializeRoutes(source *workloadapi.X509Source) {
 			return
 		}
 
+		if r.Method == http.MethodGet && p == "/sentinel/v1/secrets?reveal=true" {
+			log.DebugLn(&cid, "Handler: will list encrypted secrets")
+			route.ListEncrypted(cid, w, r, sid)
+			return
+		}
+
 		// Route to define the master key when VSECM_SAFE_MANUAL_KEY_INPUT is set.
 		// Only VSecM Sentinel is allowed to call this API endpoint.
 		// This method works only once. Once a key is set, there is no way to

--- a/app/safe/internal/server/route/list.go
+++ b/app/safe/internal/server/route/list.go
@@ -12,7 +12,6 @@ package route
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/vmware-tanzu/secrets-manager/app/safe/internal/state"
 	"github.com/vmware-tanzu/secrets-manager/core/audit"
 	reqres "github.com/vmware-tanzu/secrets-manager/core/entity/reqres/safe/v1"
@@ -95,10 +94,6 @@ func doList(cid string, w http.ResponseWriter, r *http.Request,
 		audit.Log(j)
 
 		resp, err := json.Marshal(sfr)
-
-		fmt.Println("----- RESPONSE ------")
-		fmt.Println(string(resp))
-		fmt.Println("---------------------")
 
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/app/safe/internal/server/route/list.go
+++ b/app/safe/internal/server/route/list.go
@@ -12,6 +12,7 @@ package route
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/vmware-tanzu/secrets-manager/app/safe/internal/state"
 	"github.com/vmware-tanzu/secrets-manager/core/audit"
 	reqres "github.com/vmware-tanzu/secrets-manager/core/entity/reqres/safe/v1"
@@ -94,6 +95,11 @@ func doList(cid string, w http.ResponseWriter, r *http.Request,
 		audit.Log(j)
 
 		resp, err := json.Marshal(sfr)
+
+		fmt.Println("----- RESPONSE ------")
+		fmt.Println(string(resp))
+		fmt.Println("---------------------")
+
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, err := io.WriteString(w, "List: Problem unmarshalling response")

--- a/app/safe/internal/state/state.go
+++ b/app/safe/internal/state/state.go
@@ -13,6 +13,7 @@ package state
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	entity "github.com/vmware-tanzu/secrets-manager/core/entity/data/v1"
 	"github.com/vmware-tanzu/secrets-manager/core/env"
 	"github.com/vmware-tanzu/secrets-manager/core/log"
@@ -148,6 +149,8 @@ func AllSecrets(cid string) []entity.Secret {
 }
 
 func AllSecretsEncrypted(cid string) []entity.SecretEncrypted {
+	fmt.Println("DO NOT FORGET TO ACTUALLY ENCRYPT ME!!!!!")
+
 	var result []entity.SecretEncrypted
 
 	// Check existing stored secrets files.

--- a/app/safe/internal/state/state.go
+++ b/app/safe/internal/state/state.go
@@ -13,7 +13,6 @@ package state
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
 	entity "github.com/vmware-tanzu/secrets-manager/core/entity/data/v1"
 	"github.com/vmware-tanzu/secrets-manager/core/env"
 	"github.com/vmware-tanzu/secrets-manager/core/log"
@@ -148,9 +147,10 @@ func AllSecrets(cid string) []entity.Secret {
 	return result
 }
 
+// AllSecretsEncrypted returns a slice of entity.SecretEncrypted containing all
+// secrets  currently stored. If no secrets are found, an empty slice is
+// returned.
 func AllSecretsEncrypted(cid string) []entity.SecretEncrypted {
-	fmt.Println("DO NOT FORGET TO ACTUALLY ENCRYPT ME!!!!!")
-
 	var result []entity.SecretEncrypted
 
 	// Check existing stored secrets files.

--- a/app/safe/internal/state/state.go
+++ b/app/safe/internal/state/state.go
@@ -167,9 +167,15 @@ func AllSecretsEncrypted(cid string) []entity.SecretEncrypted {
 	secrets.Range(func(key any, value any) bool {
 		v := value.(entity.SecretStored)
 
+		var vals []string
+		for _, val := range v.Values {
+			ve, _ := EncryptValue(val)
+			vals = append(vals, ve)
+		}
+
 		result = append(result, entity.SecretEncrypted{
 			Name:           v.Name,
-			EncryptedValue: v.Values,
+			EncryptedValue: vals,
 			Created:        entity.JsonTime(v.Created),
 			Updated:        entity.JsonTime(v.Updated),
 		})

--- a/app/sentinel/cmd/main.go
+++ b/app/sentinel/cmd/main.go
@@ -44,7 +44,11 @@ func main() {
 	}
 
 	if *list {
-		safe.Get()
+		if *encrypt {
+			safe.Get(true)
+			return
+		}
+		safe.Get(false)
 		return
 	}
 

--- a/app/sentinel/internal/safe/get.go
+++ b/app/sentinel/internal/safe/get.go
@@ -74,7 +74,7 @@ func acquireSource(ctx context.Context) (*workloadapi.X509Source, bool) {
 	}
 }
 
-func Get() {
+func Get(showEncryptedSecrets bool) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -100,7 +100,12 @@ func Get() {
 		return errors.New("I don’t know you, and it’s crazy: '" + id.String() + "'")
 	})
 
-	p, err := url.JoinPath(env.SafeEndpointUrl(), "/sentinel/v1/secrets")
+	safeUrl := "/sentinel/v1/secrets"
+	if showEncryptedSecrets {
+		safeUrl = "/sentinel/v1/secrets?reveal=true"
+	}
+
+	p, err := url.JoinPath(env.SafeEndpointUrl(), safeUrl)
 	if err != nil {
 		fmt.Println("Get: I am having problem generating VSecM Safe secrets api endpoint URL.")
 		fmt.Println("")

--- a/core/crypto/crypto.go
+++ b/core/crypto/crypto.go
@@ -18,6 +18,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+type Algorithm string
+
+const Age = Algorithm("age")
+const Aes = Algorithm("aes")
+
 var reader = rand.Read
 
 // RandomString generates a cryptographically-unique secure random string.

--- a/core/entity/data/v1/v1.go
+++ b/core/entity/data/v1/v1.go
@@ -40,6 +40,13 @@ type Secret struct {
 	Updated JsonTime `json:"updated"`
 }
 
+type SecretEncrypted struct {
+	Name           string   `json:"name"`
+	EncryptedValue []string `json:"value"`
+	Created        JsonTime `json:"created"`
+	Updated        JsonTime `json:"updated"`
+}
+
 type SecretMeta struct {
 	// Overrides Env.SafeUseKubernetesSecrets()
 	UseKubernetesSecret bool `json:"k8s"`

--- a/core/entity/data/v1/v1.go
+++ b/core/entity/data/v1/v1.go
@@ -27,6 +27,11 @@ type (
 	SecretFormat string
 )
 
+func (t JsonTime) MarshalJSON() ([]byte, error) {
+	stamp := fmt.Sprintf("\"%s\"", time.Time(t).Format(time.RubyDate))
+	return []byte(stamp), nil
+}
+
 var (
 	Memory BackingStore = "memory"
 	File   BackingStore = "file"
@@ -86,11 +91,6 @@ type SecretStored struct {
 	// Timestamps
 	Created time.Time
 	Updated time.Time
-}
-
-func (t JsonTime) MarshalJSON() []byte {
-	stamp := fmt.Sprintf("\"%s\"", time.Time(t).Format(time.RubyDate))
-	return []byte(stamp)
 }
 
 // handleNoTemplate is used when there is no template defined.

--- a/core/entity/data/v1/v1.go
+++ b/core/entity/data/v1/v1.go
@@ -32,6 +32,10 @@ func (t JsonTime) MarshalJSON() ([]byte, error) {
 	return []byte(stamp), nil
 }
 
+func (t JsonTime) String() string {
+	return time.Time(t).Format(time.RFC3339)
+}
+
 var (
 	Memory BackingStore = "memory"
 	File   BackingStore = "file"

--- a/core/entity/data/v1/v1.go
+++ b/core/entity/data/v1/v1.go
@@ -325,8 +325,7 @@ func (secret SecretStored) Parse() (string, error) {
 	}
 
 	if len(results) == 1 {
-		// TODO: this might be dead code, we might never hit this case parse failed will never be true if result > 0
-		// because transform() fails with unsupported fromat error and format is same for all Values.
+		// Can happen if there are N values, but only 1 was successfully parsed.
 		if parseFailed {
 			return results[0], fmt.Errorf("failed to parse secret %s", secret.Name)
 		}

--- a/core/entity/data/v1/v1_test.go
+++ b/core/entity/data/v1/v1_test.go
@@ -37,7 +37,7 @@ func TestJsonTime_MarshalJSON(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.tr.MarshalJSON(); !reflect.DeepEqual(got, tt.want) {
+			if got, _ := tt.tr.MarshalJSON(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("JsonTime.MarshalJSON() = %v, want %v", got, tt.want)
 			}
 		})

--- a/core/entity/reqres/safe/v1/v1.go
+++ b/core/entity/reqres/safe/v1/v1.go
@@ -11,6 +11,7 @@
 package v1
 
 import (
+	"github.com/vmware-tanzu/secrets-manager/core/crypto"
 	data "github.com/vmware-tanzu/secrets-manager/core/entity/data/v1"
 )
 
@@ -68,7 +69,7 @@ type SecretListResponse struct {
 
 type SecretEncryptedListResponse struct {
 	Secrets   []data.SecretEncrypted `json:"secrets"`
-	Algorithm string                 `json:"algorithm"`
+	Algorithm crypto.Algorithm       `json:"algorithm"`
 }
 
 type GenericRequest struct {

--- a/core/entity/reqres/safe/v1/v1.go
+++ b/core/entity/reqres/safe/v1/v1.go
@@ -66,6 +66,11 @@ type SecretListResponse struct {
 	Err     string        `json:"err,omitempty"`
 }
 
+type SecretEncryptedListResponse struct {
+	Secrets   []data.SecretEncrypted `json:"secrets"`
+	Algorithm string                 `json:"algorithm"`
+}
+
 type GenericRequest struct {
 	Err string `json:"err,omitempty"`
 }

--- a/docs/_pages/0090-cli.md
+++ b/docs/_pages/0090-cli.md
@@ -135,6 +135,34 @@ kubectl exec $SENTINEL -n vsecm-system -- safe \
   -d
 ```
 
+## Listing Secrets Registered to a Workload
+
+**VSecM Sentinel** does not show the secrets in plain text by design.
+However, you can use the `-l` flag to get certain metadata about the secrets
+registered to a workload.
+
+```bash
+kubectl exec $SENTINEL -n vsecm-system -- safe -l
+# Output:
+# {"secrets":[{"name":"example",
+#  "created":"Tue Jan 02 02:06:30 +0000 2024",
+#  "updated":"Tue Jan 02 02:06:30 +0000 2024"}]}
+```
+
+In addition, you can use `-l -e` to get encrypted versions of the secrets.
+If you have adequate privileges to get the VSecM root key, you can use
+the root key to decrypt the secrets.
+
+```bash
+kubectl exec $SENTINEL -n vsecm-system -- safe -l -e
+# Output:
+# {"secrets":[{"name":"example",
+#  "value":["YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0…truncated"],
+#  "created":"Tue Jan 02 02:06:30 +0000 2024",
+#  "updated":"Tue Jan 02 02:06:30 +0000 2024"}],
+#  "algorithm":"age"}
+```
+
 ## Choosing a Backing Store
 
 The registered secrets will be encrypted and backed up to


### PR DESCRIPTION
This PR includes:

* A new feature that enables sentinel to display secret values in encrypted form.
* Documentation related to it.
* Fixes to JSON formatting that enables timestamps to be printed when listing secrets.