### PR TITLE
453 fix: escape backticks in VSecMHelp.mk and fix typo in init-next-h…

### DIFF
--- a/hack/init-next-helm-chart.sh
+++ b/hack/init-next-helm-chart.sh
@@ -35,7 +35,7 @@ if [ "$#" -eq 2 ]; then
     srcBaseHelmChartPath=$gitRoot/$helmChartDirName/$baseHelmChartVersion
     newHelmChartPath=$gitRoot/$helmChartDirName/$newHelmChartVersion
 else
-    echo "Insufficient arguments, base helm chart and new helm chart verions has to be provided"
+    echo "Insufficient arguments, base helm chart and new helm chart versions have to be provided"
     exit 1
 fi
 

--- a/makefiles/VSecMHelp.mk
+++ b/makefiles/VSecMHelp.mk
@@ -16,8 +16,8 @@ help:
 	@echo "        ℹ️ This Makefile assumes you use Minikube and Docker"
 	@echo "        ℹ️ for most operations."
 	@echo "--------------------------------------------------------------------"
-	@echo "If you are on the build server, stop the cronjob first: `crontab -e`"
-	@echo "Or `sudo service cron stop`"
+	@echo "If you are on the build server, stop the cronjob first: \`crontab -e\`"
+	@echo "Or \`sudo service cron stop\`"
 	@echo "--------------------------------------------------------------------"
 
 	@if [ "`uname`" = "Darwin" ]; then \
@@ -78,8 +78,8 @@ h:
 	@echo "˃ make build;make deploy;make test;"
 	@echo "˃ make tag;"
 	@echo "--------------------------------------------------------------------"
-	@echo "If you are on the build server, stop the cronjob first: `crontab -e`"
-	@echo "Or `sudo service cron stop`"
+	@echo "If you are on the build server, stop the cronjob first: \`crontab -e\`"
+	@echo "Or \`sudo service cron stop\`"
 	@echo "--------------------------------------------------------------------"
 	@echo "˃ make build-local;make deploy-local;make test-local;"
 	@echo "˃ make build-local;make deploy-fips-local;make test-local;"


### PR DESCRIPTION
# #453 Bugfix

## Escape backticks and fix typo

1. When I execute the command make help, my terminal becomes unresponsive. It seems to be attempting to run vim.
`@echo "If you are on the build server, stop the cronjob first: 'crontab -e'"`
`@echo "Or 'sudo service cron stop'"`
2. Fix typo
`...versions have..`

## Changes

- init-next-helm-chart.sh
- VSecMHelp.mk

## Test Policy Compliance

- [-] I have added or updated unit tests for my changes.
- [-] I have included integration tests where applicable.
- [x] All new and existing tests pass successfully.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [-] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

- [-] I have made corresponding changes to the documentation (if applicable).
- [-] I have updated any relevant READMEs or wiki pages.

## Checklist

Before you submit this PR, please make sure:
- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project’s license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project’s license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
