### PR TITLE
462 fix: Added missing entity to log audits, fixed typo in cli.md

### DIFF
--- a/core/audit/audit.go
+++ b/core/audit/audit.go
@@ -117,6 +117,13 @@ func Log(e JournalEntry) {
 			e.Method, e.Url, e.SpiffeId,
 			"e:'"+v.Err+"',m:'"+string(e.Event)+"'",
 		)
+	case reqres.SecretEncryptedListResponse:
+		printAudit(
+			e.CorrelationId,
+			"SecretEncryptedListResponse",
+			e.Method, e.Url, e.SpiffeId,
+			"e:'"+v.Err+"',m:'"+string(e.Event)+"'",
+		)
 	default:
 		printAudit(
 			e.CorrelationId,

--- a/core/audit/audit_test.go
+++ b/core/audit/audit_test.go
@@ -181,6 +181,19 @@ func TestLog(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Entity_type_SecretEncryptedListResponse",
+			args: args{
+				e: JournalEntry{
+					CorrelationId: "1234",
+					Entity:        reqres.SecretEncryptedListResponse{},
+					Method:        "test_method",
+					Url:           "test_url",
+					SpiffeId:      "test_spiffeid",
+					Event:         "test_event",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/core/entity/reqres/safe/v1/v1.go
+++ b/core/entity/reqres/safe/v1/v1.go
@@ -73,6 +73,7 @@ type SecretListResponse struct {
 type SecretEncryptedListResponse struct {
 	Secrets   []data.SecretEncrypted `json:"secrets"`
 	Algorithm crypto.Algorithm       `json:"algorithm"`
+	Err       string                 `json:"err,omitempty"`
 }
 
 type SecretStringTimeListResponse struct {

--- a/docs/_pages/0090-cli.md
+++ b/docs/_pages/0090-cli.md
@@ -32,7 +32,7 @@ This section contains usage examples and documentation for
 First, find which pod belongs to `vsecm-system`:
 
 ```bash
-kubetctl get po -n vsecm-system
+kubectl get po -n vsecm-system
 ```
 
 The response to the above command will be similar to the following:


### PR DESCRIPTION
# #462 Bugfix
## Added missing entity to log audits, fixed typo in cli.md

Problem;
When I run this command through cli:
`kubectl exec $SENTINEL -n vsecm-system -- safe -l -e`

Audits logs printed:
UnknownEntity...

Solution;
`...[AUDIT] xxxxxxxx SecretEncryptedListResponse {{...`

## Changes

- core/audit/audit.go
- core/audit/audit_test.go
- core/entity/reqres/safe/v1/v1.go
- docs/_pages/0090-cli.md (Fix typo)

## Test Policy Compliance

- [x] I have added or updated unit tests for my changes.
- [x] I have included integration tests where applicable.
- [x] All new and existing tests pass successfully.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

- [-] I have made corresponding changes to the documentation (if applicable).
- [-] I have updated any relevant READMEs or wiki pages.

## Checklist

Before you submit this PR, please make sure:
- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project’s license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project’s license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
