### PR TITLE
chore(docs): change VMware, Inc. to VMware secrets manager contributors. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2023 VMware, Inc.
+Copyright 2023 – present VMware Secrets Manager contributors.
 
 This product is licensed to you under the BSD 2 clause (the "License"). You may not use this product except in compliance with the License.
 

--- a/app/init-container/cmd/main.go
+++ b/app/init-container/cmd/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/keygen/cmd/decrypt.go
+++ b/app/keygen/cmd/decrypt.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/keygen/cmd/decrypt_test.go
+++ b/app/keygen/cmd/decrypt_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/keygen/cmd/generate.go
+++ b/app/keygen/cmd/generate.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/keygen/cmd/generate_test.go
+++ b/app/keygen/cmd/generate_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/keygen/cmd/main.go
+++ b/app/keygen/cmd/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/cmd/main.go
+++ b/app/safe/cmd/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/bootstrap/bootstrap.go
+++ b/app/safe/internal/bootstrap/bootstrap.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/bootstrap/bootstrap_test.go
+++ b/app/safe/internal/bootstrap/bootstrap_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/bootstrap/k8s.go
+++ b/app/safe/internal/bootstrap/k8s.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/bootstrap/k8s_test.go
+++ b/app/safe/internal/bootstrap/k8s_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/bootstrap/privates.go
+++ b/app/safe/internal/bootstrap/privates.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/bootstrap/privates_test.go
+++ b/app/safe/internal/bootstrap/privates_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/handle/hande_test.go
+++ b/app/safe/internal/server/handle/hande_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/handle/handle.go
+++ b/app/safe/internal/server/handle/handle.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/handle/spiffe.go
+++ b/app/safe/internal/server/handle/spiffe.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/handle/spiffe_test.go
+++ b/app/safe/internal/server/handle/spiffe_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/route/delete.go
+++ b/app/safe/internal/server/route/delete.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/route/delete_test.go
+++ b/app/safe/internal/server/route/delete_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/route/fetch.go
+++ b/app/safe/internal/server/route/fetch.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/route/fetch_test.go
+++ b/app/safe/internal/server/route/fetch_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/route/list.go
+++ b/app/safe/internal/server/route/list.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/route/list_test.go
+++ b/app/safe/internal/server/route/list_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/route/receive.go
+++ b/app/safe/internal/server/route/receive.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/route/receive_test.go
+++ b/app/safe/internal/server/route/receive_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/route/secret.go
+++ b/app/safe/internal/server/route/secret.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/route/secret_test.go
+++ b/app/safe/internal/server/route/secret_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/server.go
+++ b/app/safe/internal/server/server.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/server/server_test.go
+++ b/app/safe/internal/server/server_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/internal.go
+++ b/app/safe/internal/state/internal.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/io-age.go
+++ b/app/safe/internal/state/io-age.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/io-decrypt.go
+++ b/app/safe/internal/state/io-decrypt.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/io-encrypt.go
+++ b/app/safe/internal/state/io-encrypt.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/io-persist-k8s.go
+++ b/app/safe/internal/state/io-persist-k8s.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/io-persist.go
+++ b/app/safe/internal/state/io-persist.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/io-read.go
+++ b/app/safe/internal/state/io-read.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/secret-populate.go
+++ b/app/safe/internal/state/secret-populate.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/secret-queue-delete.go
+++ b/app/safe/internal/state/secret-queue-delete.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/secret-queue-k8s-delete.go
+++ b/app/safe/internal/state/secret-queue-k8s-delete.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/secret-queue-k8s.go
+++ b/app/safe/internal/state/secret-queue-k8s.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/secret-queue.go
+++ b/app/safe/internal/state/secret-queue.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/state.go
+++ b/app/safe/internal/state/state.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/stats.go
+++ b/app/safe/internal/state/stats.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/busywait/initialization/action.go
+++ b/app/sentinel/busywait/initialization/action.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/busywait/initialization/command.go
+++ b/app/sentinel/busywait/initialization/command.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/busywait/initialization/run.go
+++ b/app/sentinel/busywait/initialization/run.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/busywait/initialization/token.go
+++ b/app/sentinel/busywait/initialization/token.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/busywait/main.go
+++ b/app/sentinel/busywait/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/cmd/help.go
+++ b/app/sentinel/cmd/help.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/cmd/help_test.go
+++ b/app/sentinel/cmd/help_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/cmd/main.go
+++ b/app/sentinel/cmd/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/cmd/parse.go
+++ b/app/sentinel/cmd/parse.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/cmd/parse_test.go
+++ b/app/sentinel/cmd/parse_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/internal/safe/get.go
+++ b/app/sentinel/internal/safe/get.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/internal/safe/get_test.go
+++ b/app/sentinel/internal/safe/get_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/internal/safe/post.go
+++ b/app/sentinel/internal/safe/post.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sentinel/internal/safe/post_test.go
+++ b/app/sentinel/internal/safe/post_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/sidecar/cmd/main.go
+++ b/app/sidecar/cmd/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/assets/frontmatter.txt
+++ b/assets/frontmatter.txt
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/assets/markdown-header.txt
+++ b/assets/markdown-header.txt
@@ -5,7 +5,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 ```

--- a/assets/sourcecode-header.txt
+++ b/assets/sourcecode-header.txt
@@ -4,6 +4,6 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */

--- a/ci/crontab.txt
+++ b/ci/crontab.txt
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/ci/poll/api.go
+++ b/ci/poll/api.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/ci/poll/env.go
+++ b/ci/poll/env.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/ci/poll/lock.go
+++ b/ci/poll/lock.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/ci/poll/main.go
+++ b/ci/poll/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/ci/poll/path.go
+++ b/ci/poll/path.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/ci/poll/pipeline.go
+++ b/ci/poll/pipeline.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/ci/poll/process.go
+++ b/ci/poll/process.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/ci/poll/state.go
+++ b/ci/poll/state.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/ci/vsecm-cluster.yaml
+++ b/ci/vsecm-cluster.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/core/audit/audit.go
+++ b/core/audit/audit.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/audit/audit_test.go
+++ b/core/audit/audit_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/crypto/crypto.go
+++ b/core/crypto/crypto.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/crypto/crypto_test.go
+++ b/core/crypto/crypto_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/crypto/decrypt.go
+++ b/core/crypto/decrypt.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/crypto/decrypt_test.go
+++ b/core/crypto/decrypt_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/crypto/key.go
+++ b/core/crypto/key.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/crypto/key_test.go
+++ b/core/crypto/key_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/crypto/parser.go
+++ b/core/crypto/parser.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/crypto/value.go
+++ b/core/crypto/value.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/entity/data/v1/v1.go
+++ b/core/entity/data/v1/v1.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/entity/data/v1/v1_test.go
+++ b/core/entity/data/v1/v1_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/entity/reqres/safe/v1/v1.go
+++ b/core/entity/reqres/safe/v1/v1.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/entity/reqres/safe/v1/v1_test.go
+++ b/core/entity/reqres/safe/v1/v1_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/endpoint.go
+++ b/core/env/endpoint.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/endpoint_test.go
+++ b/core/env/endpoint_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/init.go
+++ b/core/env/init.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/init_test.go
+++ b/core/env/init_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/keygen_test.go
+++ b/core/env/keygen_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/logging.go
+++ b/core/env/logging.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/logging_test.go
+++ b/core/env/logging_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/poll.go
+++ b/core/env/poll.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/poll_test.go
+++ b/core/env/poll_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/probe.go
+++ b/core/env/probe.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/probe_test.go
+++ b/core/env/probe_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/safe.go
+++ b/core/env/safe.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/safe_test.go
+++ b/core/env/safe_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/secret.go
+++ b/core/env/secret.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/secret_test.go
+++ b/core/env/secret_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/sidecar.go
+++ b/core/env/sidecar.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/sidecar_test.go
+++ b/core/env/sidecar_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/spiffe.go
+++ b/core/env/spiffe.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/spiffe_test.go
+++ b/core/env/spiffe_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/spiffeid.go
+++ b/core/env/spiffeid.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/spiffeid_test.go
+++ b/core/env/spiffeid_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/tls.go
+++ b/core/env/tls.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/env/tls_test.go
+++ b/core/env/tls_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/log/envinfo.go
+++ b/core/log/envinfo.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/log/envinfo_test.go
+++ b/core/log/envinfo_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/log/log.go
+++ b/core/log/log.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/log/log_test.go
+++ b/core/log/log_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/probe/privates.go
+++ b/core/probe/privates.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/probe/privates_test.go
+++ b/core/probe/privates_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/probe/probe.go
+++ b/core/probe/probe.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/probe/probe_test.go
+++ b/core/probe/probe_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/system/wait.go
+++ b/core/system/wait.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/system/wait_test.go
+++ b/core/system/wait_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/template/template.go
+++ b/core/template/template.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/template/template_test.go
+++ b/core/template/template_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/validation/validation.go
+++ b/core/validation/validation.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/core/validation/validation_test.go
+++ b/core/validation/validation_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/dockerfiles/example/init-container.Dockerfile
+++ b/dockerfiles/example/init-container.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/example/multiple-secrets.Dockerfile
+++ b/dockerfiles/example/multiple-secrets.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/example/sdk.Dockerfile
+++ b/dockerfiles/example/sdk.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/example/sidecar.Dockerfile
+++ b/dockerfiles/example/sidecar.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/util/keygen.Dockerfile
+++ b/dockerfiles/util/keygen.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-ist-fips/init-container.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/init-container.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-ist-fips/safe.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/safe.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-ist-fips/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/sentinel.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-ist-fips/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/sidecar.Dockerfile
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-ist/init-container.Dockerfile
+++ b/dockerfiles/vsecm-ist/init-container.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-ist/safe.Dockerfile
+++ b/dockerfiles/vsecm-ist/safe.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-ist/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-ist/sentinel.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-ist/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-ist/sidecar.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-photon-fips/init-container.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/init-container.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-photon-fips/safe.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/safe.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-photon-fips/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/sentinel.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-photon-fips/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/sidecar.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-photon/init-container.Dockerfile
+++ b/dockerfiles/vsecm-photon/init-container.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-photon/safe.Dockerfile
+++ b/dockerfiles/vsecm-photon/safe.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-photon/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-photon/sentinel.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/dockerfiles/vsecm-photon/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-photon/sidecar.Dockerfile
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_includes/body-blog.html
+++ b/docs/_includes/body-blog.html
@@ -303,7 +303,7 @@
 
 
 <p class="copyright">
-    Copyright © 2023-present VMware, Inc.<br><br>
+    Copyright © 2023-present VMware Secrets Manager contributors.<br><br>
     <strong>VMware Secrets Manager</strong> for Cloud-Native Apps<br>
     code is distributed under <a href="https://github.com/vmware-tanzu/secrets-manager/blob/main/LICENSE">BSD 2-Clause License</a>.<br>
     <br>

--- a/docs/_includes/body.html
+++ b/docs/_includes/body.html
@@ -271,7 +271,7 @@
 
 
 <p class="copyright">
-    Copyright © 2023-present VMware, Inc.<br><br>
+    Copyright © 2023-present VMware Secrets Manager contributors.<br><br>
     <strong>VMware Secrets Manager</strong> for Cloud-Native Apps<br>
     code is distributed under <a href="https://github.com/vmware-tanzu/secrets-manager/blob/main/LICENSE">BSD 2-Clause License</a>.<br>
 <br>

--- a/docs/_includes/toc-page.html
+++ b/docs/_includes/toc-page.html
@@ -320,7 +320,7 @@
 
 
 <p class="copyright">
-    Copyright © 2023-present VMware, Inc.<br><br>
+    Copyright © 2023-present VMware Secrets Manager contributors.<br><br>
     <strong>VMware Secrets Manager</strong> for Cloud-Native Apps<br>
     code is distributed under <a href="https://github.com/vmware-tanzu/secrets-manager/blob/main/LICENSE">BSD 2-Clause License</a>.<br>
     <br>

--- a/docs/_pages/0000-community.md
+++ b/docs/_pages/0000-community.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0001-contributor-sync.md
+++ b/docs/_pages/0001-contributor-sync.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0002-contact.md
+++ b/docs/_pages/0002-contact.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0003-maintainers.md
+++ b/docs/_pages/0003-maintainers.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0004-security.md
+++ b/docs/_pages/0004-security.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0005-blog.md
+++ b/docs/_pages/0005-blog.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0020-preface.md
+++ b/docs/_pages/0020-preface.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0021-about.md
+++ b/docs/_pages/0021-about.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0030-endorsements.md
+++ b/docs/_pages/0030-endorsements.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0031-documentation-snapshots.md
+++ b/docs/_pages/0031-documentation-snapshots.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0050-quickstart.md
+++ b/docs/_pages/0050-quickstart.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0060-philosophy.md
+++ b/docs/_pages/0060-philosophy.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0070-architecture.md
+++ b/docs/_pages/0070-architecture.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0080-installation.md
+++ b/docs/_pages/0080-installation.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0090-cli.md
+++ b/docs/_pages/0090-cli.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0100-sdk.md
+++ b/docs/_pages/0100-sdk.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0110-configuration.md
+++ b/docs/_pages/0110-configuration.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0120-use-the-source.md
+++ b/docs/_pages/0120-use-the-source.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0130-contributing.md
+++ b/docs/_pages/0130-contributing.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0131-dev-env.md
+++ b/docs/_pages/0131-dev-env.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0140-production.md
+++ b/docs/_pages/0140-production.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0180-use-cases.md
+++ b/docs/_pages/0180-use-cases.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0190-overview.md
+++ b/docs/_pages/0190-overview.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0200-sidecar.md
+++ b/docs/_pages/0200-sidecar.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0210-sdk.md
+++ b/docs/_pages/0210-sdk.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0220-init-container.md
+++ b/docs/_pages/0220-init-container.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0230-encrypt.md
+++ b/docs/_pages/0230-encrypt.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0240-transform.md
+++ b/docs/_pages/0240-transform.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0250-showcase.md
+++ b/docs/_pages/0250-showcase.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0260-changelog.md
+++ b/docs/_pages/0260-changelog.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0270-releases.md
+++ b/docs/_pages/0270-releases.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0280-roadmap.md
+++ b/docs/_pages/0280-roadmap.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0980-release-management.md
+++ b/docs/_pages/0980-release-management.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0985-governance.md
+++ b/docs/_pages/0985-governance.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_pages/0990-privacy.md
+++ b/docs/_pages/0990-privacy.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/docs/_posts/2023-08-15-keep-your-secrets.md
+++ b/docs/_posts/2023-08-15-keep-your-secrets.md
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/bundle/ConfigMap.yaml
+++ b/examples/federation-workshop/cluster-1/bundle/ConfigMap.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/bundle/Endpoint.yaml
+++ b/examples/federation-workshop/cluster-1/bundle/Endpoint.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/bundle/Federation.yaml
+++ b/examples/federation-workshop/cluster-1/bundle/Federation.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/hack/create-bundle-config-map.sh
+++ b/examples/federation-workshop/cluster-1/hack/create-bundle-config-map.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/hack/print-bundle.sh
+++ b/examples/federation-workshop/cluster-1/hack/print-bundle.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/inspector/Deployment.yaml
+++ b/examples/federation-workshop/cluster-1/inspector/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/inspector/Identity.yaml
+++ b/examples/federation-workshop/cluster-1/inspector/Identity.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/inspector/ServiceAccount.yaml
+++ b/examples/federation-workshop/cluster-1/inspector/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/netshoot/Client.yaml
+++ b/examples/federation-workshop/cluster-1/netshoot/Client.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/sentinel/Deployment.yaml
+++ b/examples/federation-workshop/cluster-1/sentinel/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/sentinel/Identity.yaml
+++ b/examples/federation-workshop/cluster-1/sentinel/Identity.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/sentinel/Namespace.yaml
+++ b/examples/federation-workshop/cluster-1/sentinel/Namespace.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-1/sentinel/ServiceAccount.yaml
+++ b/examples/federation-workshop/cluster-1/sentinel/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/bundle/ConfigMap.yaml
+++ b/examples/federation-workshop/cluster-2/bundle/ConfigMap.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/bundle/Endpoint.yaml
+++ b/examples/federation-workshop/cluster-2/bundle/Endpoint.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/bundle/Federation.yaml
+++ b/examples/federation-workshop/cluster-2/bundle/Federation.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/hack/create-bundle-config-map.sh
+++ b/examples/federation-workshop/cluster-2/hack/create-bundle-config-map.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/hack/print-bundle.sh
+++ b/examples/federation-workshop/cluster-2/hack/print-bundle.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/safe/Deployment.yaml
+++ b/examples/federation-workshop/cluster-2/safe/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/safe/Identity.yaml
+++ b/examples/federation-workshop/cluster-2/safe/Identity.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/safe/Namespace.yaml
+++ b/examples/federation-workshop/cluster-2/safe/Namespace.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/safe/Role.yaml
+++ b/examples/federation-workshop/cluster-2/safe/Role.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/safe/Secret.yaml
+++ b/examples/federation-workshop/cluster-2/safe/Secret.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/safe/Service.yaml
+++ b/examples/federation-workshop/cluster-2/safe/Service.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/federation-workshop/cluster-2/safe/ServiceAccount.yaml
+++ b/examples/federation-workshop/cluster-2/safe/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/multiple-secrets/busywait/main.go
+++ b/examples/multiple-secrets/busywait/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/examples/multiple-secrets/k8s/Deployment.yaml
+++ b/examples/multiple-secrets/k8s/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/multiple-secrets/k8s/Identity.yaml
+++ b/examples/multiple-secrets/k8s/Identity.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/multiple-secrets/k8s/ServiceAccount.yaml
+++ b/examples/multiple-secrets/k8s/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/multiple-secrets/k8s/image-override.yaml
+++ b/examples/multiple-secrets/k8s/image-override.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/multiple-secrets/k8s/kustomization.yaml
+++ b/examples/multiple-secrets/k8s/kustomization.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/multiple-secrets/main.go
+++ b/examples/multiple-secrets/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/examples/multiple-secrets/register.sh
+++ b/examples/multiple-secrets/register.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/multiple-secrets/secrets.sh
+++ b/examples/multiple-secrets/secrets.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/operator-decrpyt-secrets/reveal.sh
+++ b/examples/operator-decrpyt-secrets/reveal.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 VERSION="0.22.4"

--- a/examples/pre-vsecm-workshop/README.md
+++ b/examples/pre-vsecm-workshop/README.md
@@ -5,7 +5,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 ```

--- a/examples/pre-vsecm-workshop/delete-secret.sh
+++ b/examples/pre-vsecm-workshop/delete-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/delete-workload.sh
+++ b/examples/pre-vsecm-workshop/delete-workload.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/encrypt-secret.sh
+++ b/examples/pre-vsecm-workshop/encrypt-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/env.sh
+++ b/examples/pre-vsecm-workshop/env.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/ids/Inspector.yaml
+++ b/examples/pre-vsecm-workshop/ids/Inspector.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/ids/Workload.yaml
+++ b/examples/pre-vsecm-workshop/ids/Workload.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # *//
 

--- a/examples/pre-vsecm-workshop/init-container/Deployment.yaml
+++ b/examples/pre-vsecm-workshop/init-container/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/init-container/Secret.yaml
+++ b/examples/pre-vsecm-workshop/init-container/Secret.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/init-container/ServiceAccount.yaml
+++ b/examples/pre-vsecm-workshop/init-container/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/init-container/image-override.yaml
+++ b/examples/pre-vsecm-workshop/init-container/image-override.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/init-container/kustomization.yaml
+++ b/examples/pre-vsecm-workshop/init-container/kustomization.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/inspector/Deployment.yaml
+++ b/examples/pre-vsecm-workshop/inspector/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/inspector/ServiceAccount.yaml
+++ b/examples/pre-vsecm-workshop/inspector/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/inspector/image-override.yaml
+++ b/examples/pre-vsecm-workshop/inspector/image-override.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/inspector/kustomization.yaml
+++ b/examples/pre-vsecm-workshop/inspector/kustomization.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/install-clusterspiffeids.sh
+++ b/examples/pre-vsecm-workshop/install-clusterspiffeids.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/install-inspector.sh
+++ b/examples/pre-vsecm-workshop/install-inspector.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/install-workload-using-init-container.sh
+++ b/examples/pre-vsecm-workshop/install-workload-using-init-container.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/install-workload-using-sdk.sh
+++ b/examples/pre-vsecm-workshop/install-workload-using-sdk.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/install-workload-using-sidecar.sh
+++ b/examples/pre-vsecm-workshop/install-workload-using-sidecar.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/register-encrypted-secret.sh
+++ b/examples/pre-vsecm-workshop/register-encrypted-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/register-k8s-secret.sh
+++ b/examples/pre-vsecm-workshop/register-k8s-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/register-multiple-secrets.sh
+++ b/examples/pre-vsecm-workshop/register-multiple-secrets.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/register-plain-secret.sh
+++ b/examples/pre-vsecm-workshop/register-plain-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/register-secret-json.sh
+++ b/examples/pre-vsecm-workshop/register-secret-json.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/register-secret-yaml.sh
+++ b/examples/pre-vsecm-workshop/register-secret-yaml.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/register-transformed-secret.sh
+++ b/examples/pre-vsecm-workshop/register-transformed-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/safe-logs.sh
+++ b/examples/pre-vsecm-workshop/safe-logs.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/sdk/Deployment.yaml
+++ b/examples/pre-vsecm-workshop/sdk/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/sdk/ServiceAccount.yaml
+++ b/examples/pre-vsecm-workshop/sdk/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/sdk/image-override.yaml
+++ b/examples/pre-vsecm-workshop/sdk/image-override.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/sdk/kustomization.yaml
+++ b/examples/pre-vsecm-workshop/sdk/kustomization.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # *//
 

--- a/examples/pre-vsecm-workshop/secrets.sh
+++ b/examples/pre-vsecm-workshop/secrets.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/sidecar/Deployment.yaml
+++ b/examples/pre-vsecm-workshop/sidecar/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/sidecar/ServiceAccount.yaml
+++ b/examples/pre-vsecm-workshop/sidecar/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/sidecar/image-override.yaml
+++ b/examples/pre-vsecm-workshop/sidecar/image-override.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/sidecar/kustomization.yaml
+++ b/examples/pre-vsecm-workshop/sidecar/kustomization.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/pre-vsecm-workshop/workload-logs.sh
+++ b/examples/pre-vsecm-workshop/workload-logs.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/provide-encrypted-secrets/README.md
+++ b/examples/provide-encrypted-secrets/README.md
@@ -5,7 +5,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 ```

--- a/examples/provide-encrypted-secrets/run.sh
+++ b/examples/provide-encrypted-secrets/run.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-init-container/encrypt.sh
+++ b/examples/using-init-container/encrypt.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-init-container/k8s/Deployment.yaml
+++ b/examples/using-init-container/k8s/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-init-container/k8s/Identity.yaml
+++ b/examples/using-init-container/k8s/Identity.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-init-container/k8s/Secret.yaml
+++ b/examples/using-init-container/k8s/Secret.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-init-container/k8s/ServiceAccount.yaml
+++ b/examples/using-init-container/k8s/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-init-container/k8s/image-override.yaml
+++ b/examples/using-init-container/k8s/image-override.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-init-container/k8s/kustomization.yaml
+++ b/examples/using-init-container/k8s/kustomization.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-init-container/main.go
+++ b/examples/using-init-container/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/examples/using-init-container/register.sh
+++ b/examples/using-init-container/register.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-init-container/tail.sh
+++ b/examples/using-init-container/tail.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sdk/helper/env/main.go
+++ b/examples/using-sdk/helper/env/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/examples/using-sdk/k8s/Deployment.yaml
+++ b/examples/using-sdk/k8s/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sdk/k8s/Identity.yaml
+++ b/examples/using-sdk/k8s/Identity.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sdk/k8s/Secret.yaml
+++ b/examples/using-sdk/k8s/Secret.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sdk/k8s/ServiceAccount.yaml
+++ b/examples/using-sdk/k8s/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sdk/k8s/image-override.yaml
+++ b/examples/using-sdk/k8s/image-override.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sdk/k8s/kustomization.yaml
+++ b/examples/using-sdk/k8s/kustomization.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sdk/main.go
+++ b/examples/using-sdk/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/examples/using-sdk/register.sh
+++ b/examples/using-sdk/register.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sdk/tail.sh
+++ b/examples/using-sdk/tail.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sidecar/helper/env/main.go
+++ b/examples/using-sidecar/helper/env/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/examples/using-sidecar/k8s/Deployment.yaml
+++ b/examples/using-sidecar/k8s/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sidecar/k8s/Identity.yaml
+++ b/examples/using-sidecar/k8s/Identity.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sidecar/k8s/Secret.yaml
+++ b/examples/using-sidecar/k8s/Secret.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sidecar/k8s/ServiceAccount.yaml
+++ b/examples/using-sidecar/k8s/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sidecar/k8s/image-override.yaml
+++ b/examples/using-sidecar/k8s/image-override.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sidecar/k8s/kustomization.yaml
+++ b/examples/using-sidecar/k8s/kustomization.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sidecar/main.go
+++ b/examples/using-sidecar/main.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/examples/using-sidecar/register.sh
+++ b/examples/using-sidecar/register.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/using-sidecar/tail.sh
+++ b/examples/using-sidecar/tail.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/000-register-secret.sh
+++ b/examples/vsecm-workshop/hack/000-register-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/001-append-secret.sh
+++ b/examples/vsecm-workshop/hack/001-append-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/002-delete-secret.sh
+++ b/examples/vsecm-workshop/hack/002-delete-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/003-encrypt-secret.sh
+++ b/examples/vsecm-workshop/hack/003-encrypt-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/004-register-encrypted-secret.sh
+++ b/examples/vsecm-workshop/hack/004-register-encrypted-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/005-register-secret-json-transformation.sh
+++ b/examples/vsecm-workshop/hack/005-register-secret-json-transformation.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/006-register-secret-yaml-transformation.sh
+++ b/examples/vsecm-workshop/hack/006-register-secret-yaml-transformation.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/007-register-secret-default-transformation.sh
+++ b/examples/vsecm-workshop/hack/007-register-secret-default-transformation.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/008-register-k8s-secret.sh
+++ b/examples/vsecm-workshop/hack/008-register-k8s-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/009-register-secret-with-expiration.sh
+++ b/examples/vsecm-workshop/hack/009-register-secret-with-expiration.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/010-create-k8s-secret.sh
+++ b/examples/vsecm-workshop/hack/010-create-k8s-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/011-generate-secrets.sh
+++ b/examples/vsecm-workshop/hack/011-generate-secrets.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/012-reveal-secrets.sh
+++ b/examples/vsecm-workshop/hack/012-reveal-secrets.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/013-export-secrets.sh
+++ b/examples/vsecm-workshop/hack/013-export-secrets.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/014-get-root-key.sh
+++ b/examples/vsecm-workshop/hack/014-get-root-key.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/015-k-get-secrets.sh
+++ b/examples/vsecm-workshop/hack/015-k-get-secrets.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/015-reveal-secrets.sh
+++ b/examples/vsecm-workshop/hack/015-reveal-secrets.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 VERSION="0.22.4"

--- a/examples/vsecm-workshop/hack/env.sh
+++ b/examples/vsecm-workshop/hack/env.sh
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/list-secrets.sh
+++ b/examples/vsecm-workshop/hack/list-secrets.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/trace-safe.sh
+++ b/examples/vsecm-workshop/hack/trace-safe.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/hack/view-secret.sh
+++ b/examples/vsecm-workshop/hack/view-secret.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/ids/Example.yaml
+++ b/examples/vsecm-workshop/ids/Example.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/ids/Inspector.yaml
+++ b/examples/vsecm-workshop/ids/Inspector.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/secrets/VSecMSecretExample.yaml
+++ b/examples/vsecm-workshop/secrets/VSecMSecretExample.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/workloads/example-init-container/Deployment.yaml
+++ b/examples/vsecm-workshop/workloads/example-init-container/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/workloads/example-init-container/ServiceAccount.yaml
+++ b/examples/vsecm-workshop/workloads/example-init-container/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/workloads/inspector/Deployment.yaml
+++ b/examples/vsecm-workshop/workloads/inspector/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/workloads/inspector/ServiceAccount.yaml
+++ b/examples/vsecm-workshop/workloads/inspector/ServiceAccount.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/examples/vsecm-workshop/workloads/keycloak/Service.yaml
+++ b/examples/vsecm-workshop/workloads/keycloak/Service.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/build-ci-binary.sh
+++ b/hack/build-ci-binary.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/create-eks-cluster.sh
+++ b/hack/create-eks-cluster.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # *
 

--- a/hack/crontab-start.sh
+++ b/hack/crontab-start.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/crontab-stop.sh
+++ b/hack/crontab-stop.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/example-init-container-deploy-local.sh
+++ b/hack/example-init-container-deploy-local.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/example-init-container-deploy.sh
+++ b/hack/example-init-container-deploy.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/example-multiple-secrets-deploy-local.sh
+++ b/hack/example-multiple-secrets-deploy-local.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/example-multiple-secrets-deploy.sh
+++ b/hack/example-multiple-secrets-deploy.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/example-sdk-deploy-local.sh
+++ b/hack/example-sdk-deploy-local.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/example-sdk-deploy.sh
+++ b/hack/example-sdk-deploy.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/example-sidecar-deploy-local.sh
+++ b/hack/example-sidecar-deploy-local.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/example-sidecar-deploy.sh
+++ b/hack/example-sidecar-deploy.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/get-root-key.sh
+++ b/hack/get-root-key.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/helm-delete.sh
+++ b/hack/helm-delete.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # *
 

--- a/hack/init-next-helm-chart.sh
+++ b/hack/init-next-helm-chart.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/install-vsecm-to-eks.sh
+++ b/hack/install-vsecm-to-eks.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/k8s-get-contexts.sh
+++ b/hack/k8s-get-contexts.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # *
 

--- a/hack/mac-registry-tunnel.sh
+++ b/hack/mac-registry-tunnel.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/minikube-delete.sh
+++ b/hack/minikube-delete.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/minikube-start.sh
+++ b/hack/minikube-start.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/print-spire-bundle.sh
+++ b/hack/print-spire-bundle.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/pull.sh
+++ b/hack/pull.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/push.sh
+++ b/hack/push.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/serve-docs.sh
+++ b/hack/serve-docs.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/tag-docker.sh
+++ b/hack/tag-docker.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/tag-repos-only.sh
+++ b/hack/tag-repos-only.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/tag.sh
+++ b/hack/tag.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/uninstall.sh
+++ b/hack/uninstall.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/update-k8s-manifests.sh
+++ b/hack/update-k8s-manifests.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/update-kube-config-eks.sh
+++ b/hack/update-kube-config-eks.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/hack/web-sync.sh
+++ b/hack/web-sync.sh
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/Chart.yaml
+++ b/helm-charts/0.22.4/Chart.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/safe/Chart.yaml
+++ b/helm-charts/0.22.4/charts/safe/Chart.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/safe/templates/Deployment.yaml
+++ b/helm-charts/0.22.4/charts/safe/templates/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/safe/templates/_helpers.tpl
+++ b/helm-charts/0.22.4/charts/safe/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/safe/templates/hook-preinstall-namespace.yaml
+++ b/helm-charts/0.22.4/charts/safe/templates/hook-preinstall-namespace.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/safe/templates/hook-preinstall_role.yaml
+++ b/helm-charts/0.22.4/charts/safe/templates/hook-preinstall_role.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/safe/templates/identity.yaml
+++ b/helm-charts/0.22.4/charts/safe/templates/identity.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/safe/templates/role_binding.yaml
+++ b/helm-charts/0.22.4/charts/safe/templates/role_binding.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/safe/templates/secret.yaml
+++ b/helm-charts/0.22.4/charts/safe/templates/secret.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/safe/templates/service.yaml
+++ b/helm-charts/0.22.4/charts/safe/templates/service.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/safe/templates/serviceaccount.yaml
+++ b/helm-charts/0.22.4/charts/safe/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/safe/values.yaml
+++ b/helm-charts/0.22.4/charts/safe/values.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/sentinel/Chart.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/Chart.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/sentinel/templates/Deployment.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/templates/Deployment.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/sentinel/templates/Identity.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/templates/Identity.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/sentinel/templates/Secret.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/templates/Secret.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/sentinel/templates/ServiceAccount.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/templates/ServiceAccount.yaml
@@ -5,7 +5,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/sentinel/templates/_helpers.tpl
+++ b/helm-charts/0.22.4/charts/sentinel/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/sentinel/values.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/values.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/Chart.yaml
+++ b/helm-charts/0.22.4/charts/spire/Chart.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/templates/_helpers.tpl
+++ b/helm-charts/0.22.4/charts/spire/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/templates/crd-rbac/hook-preinstall_leader_election_role.yaml
+++ b/helm-charts/0.22.4/charts/spire/templates/crd-rbac/hook-preinstall_leader_election_role.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/templates/crd-rbac/hook-preinstall_role.yaml
+++ b/helm-charts/0.22.4/charts/spire/templates/crd-rbac/hook-preinstall_role.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/templates/crd-rbac/leader_election_role_binding.yaml
+++ b/helm-charts/0.22.4/charts/spire/templates/crd-rbac/leader_election_role_binding.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/templates/crd-rbac/role_binding.yaml
+++ b/helm-charts/0.22.4/charts/spire/templates/crd-rbac/role_binding.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/templates/hook-preinstall_spiffe-csi-driver.yaml
+++ b/helm-charts/0.22.4/charts/spire/templates/hook-preinstall_spiffe-csi-driver.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/templates/hook-preinstall_spire-namespace.yaml
+++ b/helm-charts/0.22.4/charts/spire/templates/hook-preinstall_spire-namespace.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/templates/spire-agent.yaml
+++ b/helm-charts/0.22.4/charts/spire/templates/spire-agent.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/templates/spire-controller-manager-config.yaml
+++ b/helm-charts/0.22.4/charts/spire/templates/spire-controller-manager-config.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/templates/spire-controller-manager-webhook.yaml
+++ b/helm-charts/0.22.4/charts/spire/templates/spire-controller-manager-webhook.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/templates/spire-server.yaml
+++ b/helm-charts/0.22.4/charts/spire/templates/spire-server.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/charts/spire/values.yaml
+++ b/helm-charts/0.22.4/charts/spire/values.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/helm-charts/0.22.4/crds/spire.spiffe.io_clusterfederatedtrustdomains.yaml
+++ b/helm-charts/0.22.4/crds/spire.spiffe.io_clusterfederatedtrustdomains.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 ---

--- a/helm-charts/0.22.4/crds/spire.spiffe.io_clusterspiffeids.yaml
+++ b/helm-charts/0.22.4/crds/spire.spiffe.io_clusterspiffeids.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 ---

--- a/helm-charts/0.22.4/crds/spire.spiffe.io_clusterstaticentries.yaml
+++ b/helm-charts/0.22.4/crds/spire.spiffe.io_clusterstaticentries.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 ---

--- a/helm-charts/0.22.4/crds/spire.spiffe.io_controllermanagerconfigs.yaml
+++ b/helm-charts/0.22.4/crds/spire.spiffe.io_controllermanagerconfigs.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 ---

--- a/helm-charts/0.22.4/values.yaml
+++ b/helm-charts/0.22.4/values.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/k8s/0.22.4/crds/spire.spiffe.io_clusterfederatedtrustdomains.yaml
+++ b/k8s/0.22.4/crds/spire.spiffe.io_clusterfederatedtrustdomains.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 ---

--- a/k8s/0.22.4/crds/spire.spiffe.io_clusterspiffeids.yaml
+++ b/k8s/0.22.4/crds/spire.spiffe.io_clusterspiffeids.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 ---

--- a/k8s/0.22.4/crds/spire.spiffe.io_clusterstaticentries.yaml
+++ b/k8s/0.22.4/crds/spire.spiffe.io_clusterstaticentries.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 ---

--- a/k8s/0.22.4/crds/spire.spiffe.io_controllermanagerconfigs.yaml
+++ b/k8s/0.22.4/crds/spire.spiffe.io_controllermanagerconfigs.yaml
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 ---

--- a/k8s/0.22.4/local/vsecm-distroless-fips.yaml
+++ b/k8s/0.22.4/local/vsecm-distroless-fips.yaml
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -22,7 +22,7 @@ metadata:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -47,7 +47,7 @@ automountServiceAccountToken: true
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -72,7 +72,7 @@ automountServiceAccountToken: false
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -94,7 +94,7 @@ data:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 apiVersion: v1
@@ -113,7 +113,7 @@ stringData:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -187,7 +187,7 @@ rules:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -233,7 +233,7 @@ roleRef:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -268,7 +268,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -419,7 +419,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -514,7 +514,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -543,7 +543,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/k8s/0.22.4/local/vsecm-distroless.yaml
+++ b/k8s/0.22.4/local/vsecm-distroless.yaml
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -22,7 +22,7 @@ metadata:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -47,7 +47,7 @@ automountServiceAccountToken: true
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -72,7 +72,7 @@ automountServiceAccountToken: false
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -94,7 +94,7 @@ data:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 apiVersion: v1
@@ -113,7 +113,7 @@ stringData:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -187,7 +187,7 @@ rules:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -233,7 +233,7 @@ roleRef:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -268,7 +268,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -419,7 +419,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -514,7 +514,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -543,7 +543,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/k8s/0.22.4/local/vsecm-photon-fips.yaml
+++ b/k8s/0.22.4/local/vsecm-photon-fips.yaml
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -22,7 +22,7 @@ metadata:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -47,7 +47,7 @@ automountServiceAccountToken: true
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -72,7 +72,7 @@ automountServiceAccountToken: false
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -94,7 +94,7 @@ data:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 apiVersion: v1
@@ -113,7 +113,7 @@ stringData:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -187,7 +187,7 @@ rules:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -233,7 +233,7 @@ roleRef:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -268,7 +268,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -419,7 +419,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -514,7 +514,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -543,7 +543,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/k8s/0.22.4/local/vsecm-photon.yaml
+++ b/k8s/0.22.4/local/vsecm-photon.yaml
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -22,7 +22,7 @@ metadata:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -47,7 +47,7 @@ automountServiceAccountToken: true
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -72,7 +72,7 @@ automountServiceAccountToken: false
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -94,7 +94,7 @@ data:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 apiVersion: v1
@@ -113,7 +113,7 @@ stringData:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -187,7 +187,7 @@ rules:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -233,7 +233,7 @@ roleRef:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -268,7 +268,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -419,7 +419,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -514,7 +514,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -543,7 +543,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/k8s/0.22.4/remote/vsecm-distroless-fips.yaml
+++ b/k8s/0.22.4/remote/vsecm-distroless-fips.yaml
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -22,7 +22,7 @@ metadata:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -47,7 +47,7 @@ automountServiceAccountToken: true
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -72,7 +72,7 @@ automountServiceAccountToken: false
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -94,7 +94,7 @@ data:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 apiVersion: v1
@@ -113,7 +113,7 @@ stringData:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -187,7 +187,7 @@ rules:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -233,7 +233,7 @@ roleRef:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -268,7 +268,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -419,7 +419,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -514,7 +514,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -543,7 +543,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/k8s/0.22.4/remote/vsecm-distroless.yaml
+++ b/k8s/0.22.4/remote/vsecm-distroless.yaml
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -22,7 +22,7 @@ metadata:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -47,7 +47,7 @@ automountServiceAccountToken: true
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -72,7 +72,7 @@ automountServiceAccountToken: false
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -94,7 +94,7 @@ data:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 apiVersion: v1
@@ -113,7 +113,7 @@ stringData:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -187,7 +187,7 @@ rules:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -233,7 +233,7 @@ roleRef:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -268,7 +268,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -419,7 +419,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -514,7 +514,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -543,7 +543,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/k8s/0.22.4/remote/vsecm-photon-fips.yaml
+++ b/k8s/0.22.4/remote/vsecm-photon-fips.yaml
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -22,7 +22,7 @@ metadata:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -47,7 +47,7 @@ automountServiceAccountToken: true
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -72,7 +72,7 @@ automountServiceAccountToken: false
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -94,7 +94,7 @@ data:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 apiVersion: v1
@@ -113,7 +113,7 @@ stringData:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -187,7 +187,7 @@ rules:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -233,7 +233,7 @@ roleRef:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -268,7 +268,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -419,7 +419,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -514,7 +514,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -543,7 +543,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/k8s/0.22.4/remote/vsecm-photon.yaml
+++ b/k8s/0.22.4/remote/vsecm-photon.yaml
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -22,7 +22,7 @@ metadata:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -47,7 +47,7 @@ automountServiceAccountToken: true
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -72,7 +72,7 @@ automountServiceAccountToken: false
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -94,7 +94,7 @@ data:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 apiVersion: v1
@@ -113,7 +113,7 @@ stringData:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -187,7 +187,7 @@ rules:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -233,7 +233,7 @@ roleRef:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -268,7 +268,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -419,7 +419,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -514,7 +514,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -543,7 +543,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/k8s/0.22.4/spire.yaml
+++ b/k8s/0.22.4/spire.yaml
@@ -6,7 +6,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -22,7 +22,7 @@ metadata:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -40,7 +40,7 @@ metadata:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -98,7 +98,7 @@ data:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -212,7 +212,7 @@ data:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -298,7 +298,7 @@ rules:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -353,7 +353,7 @@ roleRef:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -400,7 +400,7 @@ rules:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -682,7 +682,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
@@ -716,7 +716,7 @@ spec:
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/Git.mk
+++ b/makefiles/Git.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/Test.mk
+++ b/makefiles/Test.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMBuild.mk
+++ b/makefiles/VSecMBuild.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMDeploy.mk
+++ b/makefiles/VSecMDeploy.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMExampleInitContainer.mk
+++ b/makefiles/VSecMExampleInitContainer.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMExampleMultipleSecrets.mk
+++ b/makefiles/VSecMExampleMultipleSecrets.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMExampleSdk.mk
+++ b/makefiles/VSecMExampleSdk.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMExampleSidecar.mk
+++ b/makefiles/VSecMExampleSidecar.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMHelmUtils.mk
+++ b/makefiles/VSecMHelmUtils.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMHelp.mk
+++ b/makefiles/VSecMHelp.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMInitContainer.mk
+++ b/makefiles/VSecMInitContainer.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMKeyGen.mk
+++ b/makefiles/VSecMKeyGen.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMMacOs.mk
+++ b/makefiles/VSecMMacOs.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMSafe.mk
+++ b/makefiles/VSecMSafe.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMSentinel.mk
+++ b/makefiles/VSecMSentinel.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/makefiles/VSecMSidecar.mk
+++ b/makefiles/VSecMSidecar.mk
@@ -4,7 +4,7 @@
 # </
 # <>/  keep your secrets… secret
 # >/
-# <>/' Copyright 2023–present VMware, Inc.
+# <>/' Copyright 2023–present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 

--- a/sdk/internal/timer/timer.go
+++ b/sdk/internal/timer/timer.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/sdk/internal/timer/timer_test.go
+++ b/sdk/internal/timer/timer_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/sdk/sentry/fetch.go
+++ b/sdk/sentry/fetch.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/sdk/sentry/fetch_test.go
+++ b/sdk/sentry/fetch_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/sdk/sentry/privates.go
+++ b/sdk/sentry/privates.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/sdk/sentry/privates_test.go
+++ b/sdk/sentry/privates_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/sdk/sentry/watch.go
+++ b/sdk/sentry/watch.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/sdk/sentry/watch_test.go
+++ b/sdk/sentry/watch_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/sdk/startup/watch.go
+++ b/sdk/startup/watch.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/sdk/startup/watch_test.go
+++ b/sdk/startup/watch_test.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 


### PR DESCRIPTION
I have made a very basic change for copyright statements, replaced `VMware, Inc.` with `VMware Secrets Manager contributors.` 

resolves #487
