### PR TITLE
Ovolkan/sentinel tombstone

### DIFF
--- a/app/safe/cmd/main.go
+++ b/app/safe/cmd/main.go
@@ -47,7 +47,9 @@ func main() {
 	)
 
 	//Print the diagnostic information about the environment.
-	envVarsToPrint := []string{"APP_VERSION", "VSECM_LOG_LEVEL", "VSECM_SAFE_FIPS_COMPLIANT", "VSECM_SAFE_SPIFFEID_PREFIX", "VSECM_SAFE_TLS_PORT"}
+	envVarsToPrint := []string{"APP_VERSION", "VSECM_LOG_LEVEL",
+		"VSECM_SAFE_FIPS_COMPLIANT", "VSECM_SAFE_SPIFFEID_PREFIX",
+		"VSECM_SAFE_TLS_PORT"}
 	log.PrintEnvironmentInfo(&id, envVarsToPrint)
 
 	// Time out if things take too long.

--- a/app/safe/internal/server/handle/handle.go
+++ b/app/safe/internal/server/handle/handle.go
@@ -124,6 +124,15 @@ func InitializeRoutes(source *workloadapi.X509Source) {
 			return
 		}
 
+		if r.Method == http.MethodPost && p == "/sentinel/v1/init-completed" {
+			log.DebugLn(
+				&cid,
+				"Handler:/sentinel/v1/init-completed: will mark init completion",
+			)
+			route.InitComplete(cid, w, r, sid)
+			return
+		}
+
 		log.DebugLn(&cid, "Handler: route mismatch")
 
 		w.WriteHeader(http.StatusBadRequest)

--- a/app/safe/internal/server/route/fetch.go
+++ b/app/safe/internal/server/route/fetch.go
@@ -68,6 +68,32 @@ func handleNoSecretResponse(cid string, w http.ResponseWriter,
 	}
 }
 
+func handleInitCompleteSuccessResponse(cid string, w http.ResponseWriter,
+	j audit.JournalEntry, sfr reqres.SentinelInitCompleteResponse) {
+	j.Event = audit.EventOk
+	j.Entity = sfr
+	audit.Log(j)
+
+	resp, err := json.Marshal(sfr)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, err2 := io.WriteString(w, "Problem unmarshalling response")
+		if err2 != nil {
+			log.InfoLn(&cid, "Problem sending response", err2.Error())
+		}
+		return
+	}
+
+	log.DebugLn(&cid, "before response")
+
+	_, err = io.WriteString(w, string(resp))
+	if err != nil {
+		log.InfoLn(&cid, "Problem sending response", err.Error())
+	}
+
+	log.DebugLn(&cid, "after response")
+}
+
 func handleSuccessResponse(cid string, w http.ResponseWriter,
 	j audit.JournalEntry, sfr reqres.SecretFetchResponse) {
 	j.Event = audit.EventOk

--- a/app/safe/internal/server/route/initialization.go
+++ b/app/safe/internal/server/route/initialization.go
@@ -27,7 +27,7 @@ import (
 	"net/http"
 )
 
-func createInitializationSecret() error {
+func markInitializationSecretAsCompleted() error {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return errors.Wrap(err, "could not create client config")
@@ -80,6 +80,13 @@ func createInitializationSecret() error {
 	return nil
 }
 
+// InitComplete is called when the Sentinel has completed its initialization
+// process. It is responsible for marking the initialization process as
+// complete in the Kubernetes cluster, by updating the value of a
+// "vsecm-sentinel-init-tombstone" Secret in the "vsecm-system" namespace.
+//
+// See ./app/sentinel/internal/safe/post.go:PostInitializationComplete for the
+// corresponding sentinel-side implementation.
 func InitComplete(cid string, w http.ResponseWriter, r *http.Request, spiffeid string) {
 	if env.SafeManualKeyInput() && !state.MasterKeySet() {
 		log.InfoLn(&cid, "InitComplete: Master key not set")
@@ -115,7 +122,7 @@ func InitComplete(cid string, w http.ResponseWriter, r *http.Request, spiffeid s
 
 	// TODO: Create initialization Secret
 	// TODO: handle error.
-	err := createInitializationSecret()
+	err := markInitializationSecretAsCompleted()
 	if err != nil {
 		log.WarnLn(
 			&cid,

--- a/app/safe/internal/server/route/initialization.go
+++ b/app/safe/internal/server/route/initialization.go
@@ -120,8 +120,6 @@ func InitComplete(cid string, w http.ResponseWriter, r *http.Request, spiffeid s
 
 	log.DebugLn(&cid, "InitComplete: preparing request")
 
-	// TODO: Create initialization Secret
-	// TODO: handle error.
 	err := markInitializationSecretAsCompleted()
 	if err != nil {
 		log.WarnLn(

--- a/app/safe/internal/server/route/initialization.go
+++ b/app/safe/internal/server/route/initialization.go
@@ -1,0 +1,130 @@
+/*
+|    Protect your secrets, protect your sensitive data.
+:    Explore VMware Secrets Manager docs at https://vsecm.com/
+</
+<>/  keep your secrets… secret
+>/
+<>/' Copyright 2023–present VMware, Inc.
+>/'  SPDX-License-Identifier: BSD-2-Clause
+*/
+
+package route
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/secrets-manager/app/safe/internal/state"
+	"github.com/vmware-tanzu/secrets-manager/core/audit"
+	reqres "github.com/vmware-tanzu/secrets-manager/core/entity/reqres/safe/v1"
+	"github.com/vmware-tanzu/secrets-manager/core/env"
+	"github.com/vmware-tanzu/secrets-manager/core/log"
+	"github.com/vmware-tanzu/secrets-manager/core/validation"
+	apiV1 "k8s.io/api/core/v1"
+	kErrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"net/http"
+)
+
+func createInitializationSecret() error {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return errors.Wrap(err, "could not create client config")
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return errors.Wrap(err, "could not create client")
+	}
+
+	secretName := "vsecm-sentinel-init-tombstone"
+	namespace := "vsecm-system"
+
+	// First, try to get the existing secret
+	_, err = clientset.CoreV1().Secrets(namespace).Get(
+		context.Background(), secretName, metaV1.GetOptions{})
+
+	if kErrors.IsNotFound(err) {
+		return errors.New("initialization secret is expected to have existed.")
+	}
+
+	// Update the Secret in the cluster
+	_, err = clientset.CoreV1().Secrets(namespace).Update(
+		context.Background(),
+		&apiV1.Secret{
+			TypeMeta: metaV1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"init": []byte("complete"),
+			},
+		},
+		metaV1.UpdateOptions{
+			TypeMeta: metaV1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+		},
+	)
+
+	if err != nil {
+		return errors.Wrap(err, "error updating the secret")
+	}
+
+	return nil
+}
+
+func InitComplete(cid string, w http.ResponseWriter, r *http.Request, spiffeid string) {
+	if env.SafeManualKeyInput() && !state.MasterKeySet() {
+		log.InfoLn(&cid, "InitComplete: Master key not set")
+		return
+	}
+
+	j := audit.JournalEntry{
+		CorrelationId: cid,
+		Entity:        reqres.SentinelInitCompleteRequest{},
+		Method:        r.Method,
+		Url:           r.RequestURI,
+		SpiffeId:      spiffeid,
+		Event:         audit.EventEnter,
+	}
+
+	audit.Log(j)
+
+	if !validation.IsSentinel(spiffeid) {
+		handleBadSvidResponse(cid, w, spiffeid, j)
+		return
+	}
+
+	log.DebugLn(&cid, "InitComplete: sending response")
+
+	defer func() {
+		err := r.Body.Close()
+		if err != nil {
+			log.InfoLn(&cid, "InitComplete: Problem closing body")
+		}
+	}()
+
+	log.DebugLn(&cid, "InitComplete: preparing request")
+
+	// TODO: Create initialization Secret
+	// TODO: handle error.
+	err := createInitializationSecret()
+	if err != nil {
+		log.WarnLn(
+			&cid,
+			"InitComplete: Problem creating initialization secret",
+			err.Error(),
+		)
+	}
+
+	icr := reqres.SentinelInitCompleteResponse{}
+
+	handleInitCompleteSuccessResponse(cid, w, j, icr)
+}

--- a/app/safe/internal/server/route/initialization.go
+++ b/app/safe/internal/server/route/initialization.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/app/safe/internal/state/io-persist-k8s.go
+++ b/app/safe/internal/state/io-persist-k8s.go
@@ -67,6 +67,7 @@ func saveSecretToKubernetes(secret entity.SecretStored) error {
 	}
 
 	secretName := env.SafeSecretNamePrefix() + secret.Name
+
 	// If the secret has k8s: prefix, then do not append a prefix; use the name
 	// as is.
 	if strings.HasPrefix(secret.Name, env.StoreWorkloadAsK8sSecretPrefix()) {

--- a/core/entity/reqres/safe/v1/v1.go
+++ b/core/entity/reqres/safe/v1/v1.go
@@ -42,6 +42,14 @@ type SecretUpsertResponse struct {
 	Err string `json:"err,omitempty"`
 }
 
+type SentinelInitCompleteRequest struct {
+	Err string `json:"err,omitempty"`
+}
+
+type SentinelInitCompleteResponse struct {
+	Err string `json:"err,omitempty"`
+}
+
 type SecretFetchRequest struct {
 	Err string `json:"err,omitempty"`
 }

--- a/core/env/sentinel.go
+++ b/core/env/sentinel.go
@@ -12,6 +12,16 @@ package env
 
 import "os"
 
+// SentinelInitCommandPath returns the path to the initialization commands file
+// for VSecM Sentinel.
+//
+// It checks for an environment variable "VSECM_SENTINEL_INIT_COMMAND_PATH" and
+// uses its value as the path. If the environment variable is not set, it
+// defaults to "/opt/vsecm-sentinel/init/data".
+//
+// Returns:
+//
+//	string: The path to the Sentinel initialization commands file.
 func SentinelInitCommandPath() string {
 	p := os.Getenv("VSECM_SENTINEL_INIT_COMMAND_PATH")
 	if p == "" {
@@ -20,8 +30,19 @@ func SentinelInitCommandPath() string {
 	return p
 }
 
-// TODO: add docs and also add godocs.
-
+// SentinelInitCommandTombstonePath returns the path for the VSecM Sentinel
+// initialization command tombstone file.
+//
+// It looks for the environment variable "VSECM_SENTINEL_INIT_COMMAND_TOMBSTONE_PATH"
+// and uses its value as the path. If the environment variable is not set, it
+// defaults to "/opt/vsecm-sentinel/tombstone/init".
+//
+// This path is usually used to store a "tombstone" file or data indicating that
+// the initialization command has been executed or is no longer valid.
+//
+// Returns:
+//
+//	string: The path to the Sentinel initialization command tombstone.
 func SentinelInitCommandTombstonePath() string {
 	p := os.Getenv("VSECM_SENTINEL_INIT_COMMAND_TOMBSTONE_PATH")
 	if p == "" {

--- a/core/env/sentinel.go
+++ b/core/env/sentinel.go
@@ -1,3 +1,13 @@
+/*
+|    Protect your secrets, protect your sensitive data.
+:    Explore VMware Secrets Manager docs at https://vsecm.com/
+</
+<>/  keep your secrets… secret
+>/
+<>/' Copyright 2023–present VMware, Inc.
+>/'  SPDX-License-Identifier: BSD-2-Clause
+*/
+
 package env
 
 import "os"
@@ -6,6 +16,16 @@ func SentinelInitCommandPath() string {
 	p := os.Getenv("VSECM_SENTINEL_INIT_COMMAND_PATH")
 	if p == "" {
 		p = "/opt/vsecm-sentinel/init/data"
+	}
+	return p
+}
+
+// TODO: add docs and also add godocs.
+
+func SentinelInitCommandTombstonePath() string {
+	p := os.Getenv("VSECM_SENTINEL_INIT_COMMAND_TOMBSTONE_PATH")
+	if p == "" {
+		p = "/opt/vsecm-sentinel/tombstone/init"
 	}
 	return p
 }

--- a/core/env/sentinel.go
+++ b/core/env/sentinel.go
@@ -4,7 +4,7 @@
 </
 <>/  keep your secrets… secret
 >/
-<>/' Copyright 2023–present VMware, Inc.
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
 >/'  SPDX-License-Identifier: BSD-2-Clause
 */
 

--- a/helm-charts/0.22.4/charts/sentinel/templates/Deployment.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/templates/Deployment.yaml
@@ -50,6 +50,9 @@ spec:
             - name: init-command-volume
               # /opt/vsecm-sentinel/init/data will contain the init script.
               mountPath: /opt/vsecm-sentinel/init
+            - name : tombstone-volume
+              # /opt/vsecm-sentinel/tombstone/init will contain the tombstone file.
+              mountPath: /opt/vsecm-sentinel/tombstone
           {{- end }}
           #
           # You can configure VSecM Sentinel by providing
@@ -85,4 +88,7 @@ spec:
         - name: init-command-volume
           secret:
             secretName: vsecm-sentinel-init-secret
+        - name: tombstone-volume
+          secret:
+            secretName: vsecm-sentinel-init-tombstone
         {{- end }}

--- a/helm-charts/0.22.4/charts/sentinel/templates/Deployment.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/templates/Deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket
               readOnly: true
-          {{- if .Values.initCommand.enabled }}
+          {{- if .Values.global.sentinelInitCommand.enabled }}
             - name: init-command-volume
               # /opt/vsecm-sentinel/init/data will contain the init script.
               mountPath: /opt/vsecm-sentinel/init
@@ -84,7 +84,7 @@ spec:
           csi:
             driver: "csi.spiffe.io"
             readOnly: true
-        {{- if .Values.initCommand.enabled }}
+        {{- if .Values.global.sentinelInitCommand.enabled }}
         - name: init-command-volume
           secret:
             secretName: vsecm-sentinel-init-secret

--- a/helm-charts/0.22.4/charts/sentinel/templates/Secret.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/templates/Secret.yaml
@@ -8,7 +8,7 @@
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
-{{- if .Values.initCommand.enabled }}
+{{- if .Values.global.sentinelInitCommand.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,7 +16,7 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: {{ .Values.initCommand.command | quote }}
+  data: {{ .Values.global.sentinelInitCommand.command | quote }}
 ---
 apiVersion: v1
 kind: Secret

--- a/helm-charts/0.22.4/charts/sentinel/templates/Secret.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/templates/Secret.yaml
@@ -17,4 +17,13 @@ metadata:
 type: Opaque
 stringData:
   data: {{ .Values.initCommand.command | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsecm-sentinel-init-tombstone
+  namespace: vsecm-system
+type: Opaque
+stringData:
+  init: "not-initialized"
 {{- end }}

--- a/helm-charts/0.22.4/charts/sentinel/values.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/values.yaml
@@ -34,29 +34,29 @@ environments:
 initCommand:
   enabled: true
   #  Add any initialization command here, separated by a line with only "--"
+#  command: |
+#    sleep:1
+#    --
+#  # Example:
   command: |
-    sleep:1
+    sleep:30000
     --
-  # Example:
-  #   command: |
-  #     sleep:30000
-  #     --
-  #     w:k8s:keycloak-admin-secret
-  #     n:smo-app
-  #     s:gen:{"username":"admin-[a-z0-9]{6}","password":"[a-zA-Z0-9]{12}"}
-  #     t:{"KEYCLOAK_ADMIN_USER":"{{.username}}","KEYCLOAK_ADMIN_PASSWORD":"{{.password}}"}
-  #     --
-  #     w:k8s:keycloak-db-secret
-  #     n:smo-app
-  #     s:gen:{"username":"admin-[a-z0-9]{6}","password":"[a-zA-Z0-9]{12}"}
-  #     t:{"KEYCLOAK_DB_USER":"{{.username}}","KEYCLOAK_DB_PASSWORD":"{{.password}}"}
-  #     --
-  #     sleep:5000
-  #     --
-  #     w:keycloak
-  #     n:default
-  #     s:trigger-init
-  #     --
+    w:k8s:keycloak-admin-secret
+    n:smo-app
+    s:gen:{"username":"admin-[a-z0-9]{6}","password":"[a-zA-Z0-9]{12}"}
+    t:{"KEYCLOAK_ADMIN_USER":"{{.username}}","KEYCLOAK_ADMIN_PASSWORD":"{{.password}}"}
+    --
+    w:k8s:keycloak-db-secret
+    n:smo-app
+    s:gen:{"username":"admin-[a-z0-9]{6}","password":"[a-zA-Z0-9]{12}"}
+    t:{"KEYCLOAK_DB_USER":"{{.username}}","KEYCLOAK_DB_PASSWORD":"{{.password}}"}
+    --
+    sleep:5000
+    --
+    w:keycloak
+    n:default
+    s:trigger-init
+    --
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/0.22.4/charts/sentinel/values.yaml
+++ b/helm-charts/0.22.4/charts/sentinel/values.yaml
@@ -31,33 +31,6 @@ environments:
  - name: VSECM_SENTINEL_SPIFFEID_PREFIX
    value: "spiffe://vsecm.com/workload/vsecm-sentinel/ns/vsecm-system/sa/vsecm-sentinel/n/"
 
-initCommand:
-  enabled: true
-  #  Add any initialization command here, separated by a line with only "--"
-#  command: |
-#    sleep:1
-#    --
-#  # Example:
-  command: |
-    sleep:30000
-    --
-    w:k8s:keycloak-admin-secret
-    n:smo-app
-    s:gen:{"username":"admin-[a-z0-9]{6}","password":"[a-zA-Z0-9]{12}"}
-    t:{"KEYCLOAK_ADMIN_USER":"{{.username}}","KEYCLOAK_ADMIN_PASSWORD":"{{.password}}"}
-    --
-    w:k8s:keycloak-db-secret
-    n:smo-app
-    s:gen:{"username":"admin-[a-z0-9]{6}","password":"[a-zA-Z0-9]{12}"}
-    t:{"KEYCLOAK_DB_USER":"{{.username}}","KEYCLOAK_DB_PASSWORD":"{{.password}}"}
-    --
-    sleep:5000
-    --
-    w:keycloak
-    n:default
-    s:trigger-init
-    --
-
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/helm-charts/0.22.4/values.yaml
+++ b/helm-charts/0.22.4/values.yaml
@@ -72,4 +72,35 @@ global:
     logLevel: DEBUG
     serverPort: 8081
 
+  sentinelInitCommand:
+    enabled: true
+
+    #  Add any initialization command here, separated by a line with only "--"
+    command: |
+      sleep:1
+      --
+
+    #  Example:
+    #  ––––––––
+    #
+    #  sleep:30000
+    #  --
+    #  w:k8s:keycloak-admin-secret
+    #  n:smo-app
+    #  s:gen:{"username":"admin-[a-z0-9]{6}","password":"[a-zA-Z0-9]{12}"}
+    #  t:{"KEYCLOAK_ADMIN_USER":"{{.username}}","KEYCLOAK_ADMIN_PASSWORD":"{{.password}}"}
+    #  --
+    #  w:k8s:keycloak-db-secret
+    #  n:smo-app
+    #  s:gen:{"username":"admin-[a-z0-9]{6}","password":"[a-zA-Z0-9]{12}"}
+    #  t:{"KEYCLOAK_DB_USER":"{{.username}}","KEYCLOAK_DB_PASSWORD":"{{.password}}"}
+    #  --
+    #  sleep:5000
+    #  --
+    #  w:keycloak
+    #  n:default
+    #  s:trigger-init
+    #  --
+
+
 podAnnotations: {}

--- a/k8s/0.22.4/local/vsecm-distroless-fips.yaml
+++ b/k8s/0.22.4/local/vsecm-distroless-fips.yaml
@@ -104,7 +104,17 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:1\n--\n"
+  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+---
+# Source: vsecm/charts/sentinel/templates/Secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsecm-sentinel-init-tombstone
+  namespace: vsecm-system
+type: Opaque
+stringData:
+  init: "not-initialized"
 ---
 # Source: vsecm/charts/safe/templates/hook-preinstall_role.yaml
 # /*
@@ -463,6 +473,9 @@ spec:
             - name: init-command-volume
               # /opt/vsecm-sentinel/init/data will contain the init script.
               mountPath: /opt/vsecm-sentinel/init
+            - name : tombstone-volume
+              # /opt/vsecm-sentinel/tombstone/init will contain the tombstone file.
+              mountPath: /opt/vsecm-sentinel/tombstone
           #
           # You can configure VSecM Sentinel by providing
           # environment variables.
@@ -506,6 +519,9 @@ spec:
         - name: init-command-volume
           secret:
             secretName: vsecm-sentinel-init-secret
+        - name: tombstone-volume
+          secret:
+            secretName: vsecm-sentinel-init-tombstone
 ---
 # Source: vsecm/charts/safe/templates/identity.yaml
 # /*

--- a/k8s/0.22.4/local/vsecm-distroless-fips.yaml
+++ b/k8s/0.22.4/local/vsecm-distroless-fips.yaml
@@ -104,7 +104,7 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+  data: "sleep:1\n--\n"
 ---
 # Source: vsecm/charts/sentinel/templates/Secret.yaml
 apiVersion: v1

--- a/k8s/0.22.4/local/vsecm-distroless.yaml
+++ b/k8s/0.22.4/local/vsecm-distroless.yaml
@@ -104,7 +104,17 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:1\n--\n"
+  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+---
+# Source: vsecm/charts/sentinel/templates/Secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsecm-sentinel-init-tombstone
+  namespace: vsecm-system
+type: Opaque
+stringData:
+  init: "not-initialized"
 ---
 # Source: vsecm/charts/safe/templates/hook-preinstall_role.yaml
 # /*
@@ -463,6 +473,9 @@ spec:
             - name: init-command-volume
               # /opt/vsecm-sentinel/init/data will contain the init script.
               mountPath: /opt/vsecm-sentinel/init
+            - name : tombstone-volume
+              # /opt/vsecm-sentinel/tombstone/init will contain the tombstone file.
+              mountPath: /opt/vsecm-sentinel/tombstone
           #
           # You can configure VSecM Sentinel by providing
           # environment variables.
@@ -506,6 +519,9 @@ spec:
         - name: init-command-volume
           secret:
             secretName: vsecm-sentinel-init-secret
+        - name: tombstone-volume
+          secret:
+            secretName: vsecm-sentinel-init-tombstone
 ---
 # Source: vsecm/charts/safe/templates/identity.yaml
 # /*

--- a/k8s/0.22.4/local/vsecm-distroless.yaml
+++ b/k8s/0.22.4/local/vsecm-distroless.yaml
@@ -104,7 +104,7 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+  data: "sleep:1\n--\n"
 ---
 # Source: vsecm/charts/sentinel/templates/Secret.yaml
 apiVersion: v1

--- a/k8s/0.22.4/local/vsecm-photon-fips.yaml
+++ b/k8s/0.22.4/local/vsecm-photon-fips.yaml
@@ -104,7 +104,17 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:1\n--\n"
+  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+---
+# Source: vsecm/charts/sentinel/templates/Secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsecm-sentinel-init-tombstone
+  namespace: vsecm-system
+type: Opaque
+stringData:
+  init: "not-initialized"
 ---
 # Source: vsecm/charts/safe/templates/hook-preinstall_role.yaml
 # /*
@@ -463,6 +473,9 @@ spec:
             - name: init-command-volume
               # /opt/vsecm-sentinel/init/data will contain the init script.
               mountPath: /opt/vsecm-sentinel/init
+            - name : tombstone-volume
+              # /opt/vsecm-sentinel/tombstone/init will contain the tombstone file.
+              mountPath: /opt/vsecm-sentinel/tombstone
           #
           # You can configure VSecM Sentinel by providing
           # environment variables.
@@ -506,6 +519,9 @@ spec:
         - name: init-command-volume
           secret:
             secretName: vsecm-sentinel-init-secret
+        - name: tombstone-volume
+          secret:
+            secretName: vsecm-sentinel-init-tombstone
 ---
 # Source: vsecm/charts/safe/templates/identity.yaml
 # /*

--- a/k8s/0.22.4/local/vsecm-photon-fips.yaml
+++ b/k8s/0.22.4/local/vsecm-photon-fips.yaml
@@ -104,7 +104,7 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+  data: "sleep:1\n--\n"
 ---
 # Source: vsecm/charts/sentinel/templates/Secret.yaml
 apiVersion: v1

--- a/k8s/0.22.4/local/vsecm-photon.yaml
+++ b/k8s/0.22.4/local/vsecm-photon.yaml
@@ -104,7 +104,17 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:1\n--\n"
+  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+---
+# Source: vsecm/charts/sentinel/templates/Secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsecm-sentinel-init-tombstone
+  namespace: vsecm-system
+type: Opaque
+stringData:
+  init: "not-initialized"
 ---
 # Source: vsecm/charts/safe/templates/hook-preinstall_role.yaml
 # /*
@@ -463,6 +473,9 @@ spec:
             - name: init-command-volume
               # /opt/vsecm-sentinel/init/data will contain the init script.
               mountPath: /opt/vsecm-sentinel/init
+            - name : tombstone-volume
+              # /opt/vsecm-sentinel/tombstone/init will contain the tombstone file.
+              mountPath: /opt/vsecm-sentinel/tombstone
           #
           # You can configure VSecM Sentinel by providing
           # environment variables.
@@ -506,6 +519,9 @@ spec:
         - name: init-command-volume
           secret:
             secretName: vsecm-sentinel-init-secret
+        - name: tombstone-volume
+          secret:
+            secretName: vsecm-sentinel-init-tombstone
 ---
 # Source: vsecm/charts/safe/templates/identity.yaml
 # /*

--- a/k8s/0.22.4/local/vsecm-photon.yaml
+++ b/k8s/0.22.4/local/vsecm-photon.yaml
@@ -104,7 +104,7 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+  data: "sleep:1\n--\n"
 ---
 # Source: vsecm/charts/sentinel/templates/Secret.yaml
 apiVersion: v1

--- a/k8s/0.22.4/remote/vsecm-distroless-fips.yaml
+++ b/k8s/0.22.4/remote/vsecm-distroless-fips.yaml
@@ -104,7 +104,17 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:1\n--\n"
+  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+---
+# Source: vsecm/charts/sentinel/templates/Secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsecm-sentinel-init-tombstone
+  namespace: vsecm-system
+type: Opaque
+stringData:
+  init: "not-initialized"
 ---
 # Source: vsecm/charts/safe/templates/hook-preinstall_role.yaml
 # /*
@@ -463,6 +473,9 @@ spec:
             - name: init-command-volume
               # /opt/vsecm-sentinel/init/data will contain the init script.
               mountPath: /opt/vsecm-sentinel/init
+            - name : tombstone-volume
+              # /opt/vsecm-sentinel/tombstone/init will contain the tombstone file.
+              mountPath: /opt/vsecm-sentinel/tombstone
           #
           # You can configure VSecM Sentinel by providing
           # environment variables.
@@ -506,6 +519,9 @@ spec:
         - name: init-command-volume
           secret:
             secretName: vsecm-sentinel-init-secret
+        - name: tombstone-volume
+          secret:
+            secretName: vsecm-sentinel-init-tombstone
 ---
 # Source: vsecm/charts/safe/templates/identity.yaml
 # /*

--- a/k8s/0.22.4/remote/vsecm-distroless-fips.yaml
+++ b/k8s/0.22.4/remote/vsecm-distroless-fips.yaml
@@ -104,7 +104,7 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+  data: "sleep:1\n--\n"
 ---
 # Source: vsecm/charts/sentinel/templates/Secret.yaml
 apiVersion: v1

--- a/k8s/0.22.4/remote/vsecm-distroless.yaml
+++ b/k8s/0.22.4/remote/vsecm-distroless.yaml
@@ -104,7 +104,17 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:1\n--\n"
+  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+---
+# Source: vsecm/charts/sentinel/templates/Secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsecm-sentinel-init-tombstone
+  namespace: vsecm-system
+type: Opaque
+stringData:
+  init: "not-initialized"
 ---
 # Source: vsecm/charts/safe/templates/hook-preinstall_role.yaml
 # /*
@@ -463,6 +473,9 @@ spec:
             - name: init-command-volume
               # /opt/vsecm-sentinel/init/data will contain the init script.
               mountPath: /opt/vsecm-sentinel/init
+            - name : tombstone-volume
+              # /opt/vsecm-sentinel/tombstone/init will contain the tombstone file.
+              mountPath: /opt/vsecm-sentinel/tombstone
           #
           # You can configure VSecM Sentinel by providing
           # environment variables.
@@ -506,6 +519,9 @@ spec:
         - name: init-command-volume
           secret:
             secretName: vsecm-sentinel-init-secret
+        - name: tombstone-volume
+          secret:
+            secretName: vsecm-sentinel-init-tombstone
 ---
 # Source: vsecm/charts/safe/templates/identity.yaml
 # /*

--- a/k8s/0.22.4/remote/vsecm-distroless.yaml
+++ b/k8s/0.22.4/remote/vsecm-distroless.yaml
@@ -104,7 +104,7 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+  data: "sleep:1\n--\n"
 ---
 # Source: vsecm/charts/sentinel/templates/Secret.yaml
 apiVersion: v1

--- a/k8s/0.22.4/remote/vsecm-photon-fips.yaml
+++ b/k8s/0.22.4/remote/vsecm-photon-fips.yaml
@@ -104,7 +104,17 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:1\n--\n"
+  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+---
+# Source: vsecm/charts/sentinel/templates/Secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsecm-sentinel-init-tombstone
+  namespace: vsecm-system
+type: Opaque
+stringData:
+  init: "not-initialized"
 ---
 # Source: vsecm/charts/safe/templates/hook-preinstall_role.yaml
 # /*
@@ -463,6 +473,9 @@ spec:
             - name: init-command-volume
               # /opt/vsecm-sentinel/init/data will contain the init script.
               mountPath: /opt/vsecm-sentinel/init
+            - name : tombstone-volume
+              # /opt/vsecm-sentinel/tombstone/init will contain the tombstone file.
+              mountPath: /opt/vsecm-sentinel/tombstone
           #
           # You can configure VSecM Sentinel by providing
           # environment variables.
@@ -506,6 +519,9 @@ spec:
         - name: init-command-volume
           secret:
             secretName: vsecm-sentinel-init-secret
+        - name: tombstone-volume
+          secret:
+            secretName: vsecm-sentinel-init-tombstone
 ---
 # Source: vsecm/charts/safe/templates/identity.yaml
 # /*

--- a/k8s/0.22.4/remote/vsecm-photon-fips.yaml
+++ b/k8s/0.22.4/remote/vsecm-photon-fips.yaml
@@ -104,7 +104,7 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+  data: "sleep:1\n--\n"
 ---
 # Source: vsecm/charts/sentinel/templates/Secret.yaml
 apiVersion: v1

--- a/k8s/0.22.4/remote/vsecm-photon.yaml
+++ b/k8s/0.22.4/remote/vsecm-photon.yaml
@@ -104,7 +104,17 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:1\n--\n"
+  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+---
+# Source: vsecm/charts/sentinel/templates/Secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsecm-sentinel-init-tombstone
+  namespace: vsecm-system
+type: Opaque
+stringData:
+  init: "not-initialized"
 ---
 # Source: vsecm/charts/safe/templates/hook-preinstall_role.yaml
 # /*
@@ -463,6 +473,9 @@ spec:
             - name: init-command-volume
               # /opt/vsecm-sentinel/init/data will contain the init script.
               mountPath: /opt/vsecm-sentinel/init
+            - name : tombstone-volume
+              # /opt/vsecm-sentinel/tombstone/init will contain the tombstone file.
+              mountPath: /opt/vsecm-sentinel/tombstone
           #
           # You can configure VSecM Sentinel by providing
           # environment variables.
@@ -506,6 +519,9 @@ spec:
         - name: init-command-volume
           secret:
             secretName: vsecm-sentinel-init-secret
+        - name: tombstone-volume
+          secret:
+            secretName: vsecm-sentinel-init-tombstone
 ---
 # Source: vsecm/charts/safe/templates/identity.yaml
 # /*

--- a/k8s/0.22.4/remote/vsecm-photon.yaml
+++ b/k8s/0.22.4/remote/vsecm-photon.yaml
@@ -104,7 +104,7 @@ metadata:
   namespace: vsecm-system
 type: Opaque
 stringData:
-  data: "sleep:30000\n--\nw:k8s:keycloak-admin-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_ADMIN_USER\":\"{{.username}}\",\"KEYCLOAK_ADMIN_PASSWORD\":\"{{.password}}\"}\n--\nw:k8s:keycloak-db-secret\nn:smo-app\ns:gen:{\"username\":\"admin-[a-z0-9]{6}\",\"password\":\"[a-zA-Z0-9]{12}\"}\nt:{\"KEYCLOAK_DB_USER\":\"{{.username}}\",\"KEYCLOAK_DB_PASSWORD\":\"{{.password}}\"}\n--\nsleep:5000\n--\nw:keycloak\nn:default\ns:trigger-init\n--\n"
+  data: "sleep:1\n--\n"
 ---
 # Source: vsecm/charts/sentinel/templates/Secret.yaml
 apiVersion: v1


### PR DESCRIPTION
# Adds a Tombstone Secret to VSecm Sentinel

Adds the tombstone so that when VSecM Sentinel is evicted, it does not re-run the initialization commands.

Also, fixes #479.

Tested on the build server, unit and staging tests pass with flying colors.

## Changes

List the major changes you have made in bullet points:

- Added a tombstone secret.
- VSecM sentinel modifies the secret when its initialization is done.

## Test Policy Compliance

We will need to add relevant tests in a follow-up PR.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

I’ll update the docs as a separate PR.

## Checklist

Before you submit this PR, please make sure:

- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project’s license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project’s license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
