### PR TITLE
✨ feat(VSecM Safe): 504-Add backoff policy to create/update k8s secrets

### DIFF
--- a/app/safe/README.md
+++ b/app/safe/README.md
@@ -10,3 +10,4 @@
 **VSecM Safe** is the store that keeps your secrets secret.
 
 Check out more details in the [official documentation](https://vsecm.com/).
+    - 

--- a/app/safe/internal/backoff/retry.go
+++ b/app/safe/internal/backoff/retry.go
@@ -1,0 +1,93 @@
+package backoff
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+)
+
+// Strategy is a configuration for the backoff strategy to use when retrying operations.
+type Strategy struct {
+	// Maximum number of retries before giving up (inclusive)
+	// Default is 5
+	MaxRetries int // Maximum number of retries before giving up (inclusive)
+	// Maximum delay to use between retries (in milliseconds)
+	// If Exponential is true, this is the initial delay
+	// Default is 1000
+	Delay int
+
+	// Whether to use exponential backoff or not (if false, constant delay is used)
+	// Default is false
+	Exponential bool
+	// Maximum duration to wait between retries (in milliseconds)
+	// Default is 10 seconds
+	MaxDuration time.Duration
+}
+
+// Retry is a helper function to retry an operation with the given strategy. It returns an error if the operation fails after all retries.
+func Retry(ns string, f func() error, s Strategy) error {
+	s = withDefaults(s)
+	var err error
+
+	for i := 0; i <= s.MaxRetries; i++ {
+		err = f()
+		if err == nil {
+			return nil
+		}
+
+		var retryDelay time.Duration
+		// if exponential backoff is enabled then delay increases exponentially
+		if s.Exponential {
+			// Calculate the delay for the current attempt. The delay is 2^i seconds.
+			delay := time.Duration(math.Pow(2, float64(i))) * time.Second
+			// Some randomness to avoid the thundering herd problem.
+			delay += time.Duration(rand.Intn(s.Delay)) * time.Millisecond
+			if delay > s.MaxDuration {
+				delay = s.MaxDuration
+			}
+
+			retryDelay = delay
+		} else { // otherwise delay is constant for all retries
+			retryDelay = time.Duration(s.Delay) * time.Millisecond
+		}
+
+		time.Sleep(retryDelay)
+		fmt.Println("Retrying after", retryDelay, "ms", "for", ns, "namespace", "attempt", i+1, "of", s.MaxRetries+1)
+	}
+
+	return err
+}
+
+// RetryExponential is a helper function to retry an operation with exponential backoff.
+func RetryExponential(ns string, f func() error) error {
+	return Retry(ns, f, Strategy{
+		MaxRetries:  5,
+		Delay:       1000,
+		Exponential: true,
+		MaxDuration: 10 * time.Second,
+	})
+}
+
+// RetryLinear is a helper function to retry an operation with linear backoff.
+func RetryLinear(ns string, f func() error) error {
+	return Retry(ns, f, Strategy{
+		MaxRetries: 5,
+		Delay:      1000,
+	})
+}
+
+// withDefaults sets default values for the strategy if they are not set.
+func withDefaults(s Strategy) Strategy {
+	if s.MaxRetries == 0 {
+		s.MaxRetries = 5
+	}
+	if s.Delay == 0 {
+		s.Delay = 1000
+	}
+	if s.Exponential && s.MaxDuration == 0 {
+		s.MaxDuration = 10 * time.Second
+	}
+
+	return s
+}

--- a/app/safe/internal/backoff/retry.go
+++ b/app/safe/internal/backoff/retry.go
@@ -1,3 +1,13 @@
+/*
+|    Protect your secrets, protect your sensitive data.
+:    Explore VMware Secrets Manager docs at https://vsecm.com/
+</
+<>/  keep your secrets… secret
+>/
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
+>/'  SPDX-License-Identifier: BSD-2-Clause
+*/
+
 package backoff
 
 import (
@@ -69,8 +79,8 @@ func RetryExponential(ns string, f func() error) error {
 	})
 }
 
-// RetryLinear is a helper function to retry an operation with linear backoff.
-func RetryLinear(ns string, f func() error) error {
+// RetryFixed is a helper function to retry an operation with fixed backoff.
+func RetryFixed(ns string, f func() error) error {
 	return Retry(ns, f, Strategy{
 		MaxRetries: 5,
 		Delay:      1000,

--- a/app/safe/internal/backoff/retry_test.go
+++ b/app/safe/internal/backoff/retry_test.go
@@ -1,0 +1,126 @@
+package backoff
+
+import (
+	"errors"
+	"testing"
+)
+
+// mockOperation simulates an operation that fails a specified number of times before succeeding.
+func mockOperation(failuresBeforeSuccess int) func() error {
+	calls := 0
+	return func() error {
+		if calls < failuresBeforeSuccess {
+			calls++
+			return errors.New("operation failed")
+		}
+		return nil
+	}
+}
+
+func TestRetry(t *testing.T) {
+	tests := []struct {
+		name                  string
+		failuresBeforeSuccess int
+		strategy              Strategy
+		expectError           bool
+	}{
+		{
+			name:                  "SuccessWithoutRetry",
+			failuresBeforeSuccess: 0,
+			strategy:              Strategy{MaxRetries: 5, Delay: 10},
+			expectError:           false,
+		},
+		{
+			name:                  "SuccessAfterRetries",
+			failuresBeforeSuccess: 3,
+			strategy:              Strategy{MaxRetries: 5, Delay: 10},
+			expectError:           false,
+		},
+		{
+			name:                  "FailAllRetries",
+			failuresBeforeSuccess: 6,
+			strategy:              Strategy{MaxRetries: 5, Delay: 10},
+			expectError:           true,
+		},
+		{
+			name: "WithDefaultStrategy",
+			// Default strategy is MaxRetries: 5, Delay: 1000, Exponential: false, Multiplier: 2
+			failuresBeforeSuccess: 3,
+			strategy:              Strategy{},
+			expectError:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := mockOperation(tt.failuresBeforeSuccess)
+			err := Retry("test", f, tt.strategy)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Expected error: %v, got: %v", tt.expectError, err != nil)
+			}
+		})
+	}
+}
+
+func TestRetryExponential(t *testing.T) {
+	tests := []struct {
+		name                  string
+		failuresBeforeSuccess int
+		expectError           bool
+	}{
+		{
+			name:                  "SuccessAfterRetries",
+			failuresBeforeSuccess: 2,
+			expectError:           false,
+		},
+		{
+			name:                  "FailAllRetries",
+			failuresBeforeSuccess: 6, // Exceeds the default 5 retries
+			expectError:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//t.Parallel()
+
+			f := mockOperation(tt.failuresBeforeSuccess)
+			err := RetryExponential("testExponential: "+tt.name, f)
+			if (err != nil) != tt.expectError {
+				t.Errorf("%s: expected error: %v, got: %v", tt.name, tt.expectError, err != nil)
+			}
+		})
+	}
+}
+
+func TestRetryLinear(t *testing.T) {
+	tests := []struct {
+		name                  string
+		failuresBeforeSuccess int
+		expectError           bool
+	}{
+		{
+			name:                  "SuccessAfterRetries",
+			failuresBeforeSuccess: 1,
+			expectError:           false,
+		},
+		{
+			name:                  "FailAllRetries",
+			failuresBeforeSuccess: 6, // Exceeds the default 5 retries
+			expectError:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f := mockOperation(tt.failuresBeforeSuccess)
+			err := RetryLinear("testLinear: "+tt.name, f)
+			if (err != nil) != tt.expectError {
+				t.Errorf("%s: expected error: %v, got: %v", tt.name, tt.expectError, err != nil)
+			}
+		})
+	}
+}

--- a/app/safe/internal/backoff/retry_test.go
+++ b/app/safe/internal/backoff/retry_test.go
@@ -1,3 +1,13 @@
+/*
+|    Protect your secrets, protect your sensitive data.
+:    Explore VMware Secrets Manager docs at https://vsecm.com/
+</
+<>/  keep your secrets… secret
+>/
+<>/' Copyright 2023–present VMware Secrets Manager contributors.
+>/'  SPDX-License-Identifier: BSD-2-Clause
+*/
+
 package backoff
 
 import (
@@ -95,7 +105,7 @@ func TestRetryExponential(t *testing.T) {
 	}
 }
 
-func TestRetryLinear(t *testing.T) {
+func TestRetryFixed(t *testing.T) {
 	tests := []struct {
 		name                  string
 		failuresBeforeSuccess int
@@ -117,7 +127,7 @@ func TestRetryLinear(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			f := mockOperation(tt.failuresBeforeSuccess)
-			err := RetryLinear("testLinear: "+tt.name, f)
+			err := RetryFixed("testFixed: "+tt.name, f)
 			if (err != nil) != tt.expectError {
 				t.Errorf("%s: expected error: %v, got: %v", tt.name, tt.expectError, err != nil)
 			}

--- a/app/safe/internal/bootstrap/privates.go
+++ b/app/safe/internal/bootstrap/privates.go
@@ -56,7 +56,7 @@ func persistKeys(privateKey, publicKey, aesSeed string) error {
 	}
 
 	// Update the Secret in the cluster
-	err = backoff.RetryLinear(
+	err = backoff.RetryFixed(
 		env.SystemNamespace(),
 		func() error {
 			_, err = k8sApi.CoreV1().Secrets(env.SystemNamespace()).Update(

--- a/app/safe/internal/bootstrap/privates.go
+++ b/app/safe/internal/bootstrap/privates.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/secrets-manager/app/safe/internal/backoff"
 	"github.com/vmware-tanzu/secrets-manager/app/safe/internal/state"
 	"github.com/vmware-tanzu/secrets-manager/core/crypto"
 	"github.com/vmware-tanzu/secrets-manager/core/env"
@@ -55,30 +56,35 @@ func persistKeys(privateKey, publicKey, aesSeed string) error {
 	}
 
 	// Update the Secret in the cluster
-	_, err = k8sApi.CoreV1().Secrets(env.SystemNamespace()).Update(
-		context.Background(),
-		&v1.Secret{
-			TypeMeta: metaV1.TypeMeta{
-				Kind:       "Secret",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metaV1.ObjectMeta{
-				Name:      env.SafeAgeKeySecretName(),
-				Namespace: env.SystemNamespace(),
-				Annotations: map[string]string{
-					"kubectl.kubernetes.io/last-applied-configuration": string(secretConfigJSON),
+	err = backoff.RetryLinear(
+		env.SystemNamespace(),
+		func() error {
+			_, err = k8sApi.CoreV1().Secrets(env.SystemNamespace()).Update(
+				context.Background(),
+				&v1.Secret{
+					TypeMeta: metaV1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metaV1.ObjectMeta{
+						Name:      env.SafeAgeKeySecretName(),
+						Namespace: env.SystemNamespace(),
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/last-applied-configuration": string(secretConfigJSON),
+						},
+					},
+					Data: data,
 				},
-			},
-			Data: data,
-		},
-		metaV1.UpdateOptions{
-			TypeMeta: metaV1.TypeMeta{
-				Kind:       "Secret",
-				APIVersion: "v1",
-			},
+				metaV1.UpdateOptions{
+					TypeMeta: metaV1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+				},
+			)
+			return err
 		},
 	)
-
 	if err != nil {
 		return errors.Wrap(err, "Error creating the secret")
 	}

--- a/app/safe/internal/server/route/initialization.go
+++ b/app/safe/internal/server/route/initialization.go
@@ -51,7 +51,7 @@ func markInitializationSecretAsCompleted() error {
 	}
 
 	// Update the Secret in the cluster
-	err = backoff.RetryLinear(
+	err = backoff.RetryFixed(
 		namespace,
 		func() error {
 			_, err = clientset.CoreV1().Secrets(namespace).Update(

--- a/app/safe/internal/state/io-persist-k8s.go
+++ b/app/safe/internal/state/io-persist-k8s.go
@@ -92,7 +92,7 @@ func saveSecretToKubernetes(secret entity.SecretStored) error {
 
 		if kErrors.IsNotFound(err) {
 			// Create the Secret in the cluster with a backoff.
-			err = backoff.RetryLinear(
+			err = backoff.RetryFixed(
 				ns,
 				func() error {
 					// Create the Secret in the cluster
@@ -129,7 +129,7 @@ func saveSecretToKubernetes(secret entity.SecretStored) error {
 		// Secret is found in the cluster.
 
 		// Update the Secret in the cluster
-		err = backoff.RetryLinear(
+		err = backoff.RetryFixed(
 			ns,
 			func() error {
 				_, err = clientset.CoreV1().Secrets(ns).Update(


### PR DESCRIPTION
# Add Backoff Policy to Create/Update k8s Secrets

## Description

This PR introduces a retry mechanism with an exponential and fixed backoff policy to VSecM Safe. The goal of this feature is to enhance the resilience of the system by gracefully handling transient failures in operations that are prone to fail due to temporary issues. Since issue #504 only mentions k8s secret creation/update operations, the applied scope of this feature is limited to the issue's scope.

## Changes

- /app/safe/internal/backoff package created.
- Following features added to the backoff package:
    - Exponential Backoff
    - Fixed Backoff
    - Configurable Parameters
    - Jitter
- Applied a retry mechanism with fixed backoff to k8s secrets create/update operations. Affected files:
    - app/safe/internal/bootstrap/privates.go
    - app/safe/internal/state/io-persist-k8s.go
    - app/safe/internal/server/route/initialization.go

## Test Policy Compliance

- [x] I have added or updated unit tests for my changes.
- [x] I have included integration tests where applicable.
- [x] All new and existing tests pass successfully.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

- [x] I have made corresponding changes to the documentation (if applicable).
- [x] I have updated any relevant READMEs or wiki pages.

## Additional Comments

The backoff package can be moved outside the `.../app/safe/...` since it can be used across the project.

## Checklist

Before you submit this PR, please make sure:
- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project’s license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project’s license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
