### PR TITLE
✨ feat(VSecM Safe): Delete safe-managed assoc k8s secrets

### DIFF
--- a/app/safe/cmd/main.go
+++ b/app/safe/cmd/main.go
@@ -49,7 +49,7 @@ func main() {
 	//Print the diagnostic information about the environment.
 	envVarsToPrint := []string{"APP_VERSION", "VSECM_LOG_LEVEL",
 		"VSECM_SAFE_FIPS_COMPLIANT", "VSECM_SAFE_SPIFFEID_PREFIX",
-		"VSECM_SAFE_TLS_PORT"}
+		"VSECM_SAFE_TLS_PORT", "VSECM_SAFE_REMOVE_LINKED_K8S_SECRETS"}
 	log.PrintEnvironmentInfo(&id, envVarsToPrint)
 
 	// Time out if things take too long.

--- a/app/safe/internal/state/secret-queue-k8s-delete.go
+++ b/app/safe/internal/state/secret-queue-k8s-delete.go
@@ -11,18 +11,100 @@
 package state
 
 import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/secrets-manager/app/safe/internal/backoff"
 	entity "github.com/vmware-tanzu/secrets-manager/core/entity/data/v1"
 	"github.com/vmware-tanzu/secrets-manager/core/env"
+	"github.com/vmware-tanzu/secrets-manager/core/log"
+	kErrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"strings"
 )
 
 // The secrets put here are synced with their Kubernetes Secret counterparts.
 var k8sSecretDeleteQueue = make(chan entity.SecretStored, env.SafeK8sSecretDeleteBufferSize())
 
 func processK8sSecretDeleteQueue() {
-	// id := "AEGIHK8D"
+	errChan := make(chan error)
+	id := "AEGIHK8D"
 
-	// No need to implement this; but we’ll keep the placeholder here, in case
-	// we find a need for it in the future.
-	//
-	// @see https://github.com/vmware-tanzu/secrets-manager/issues/268
+	if env.SafeRemoveLinkedK8sSecrets() {
+		go func() {
+			for e := range errChan {
+				// If the `deleteSecretFromKubernetes` operation spews out an error, log it.
+				log.ErrorLn(&id, "processK8sSecretDeleteQueue: error deleting secret:", e.Error())
+			}
+		}()
+
+		for secret := range k8sSecretDeleteQueue {
+			go deleteSecretFromKubernetes(secret, errChan)
+		}
+	} else {
+		log.InfoLn(&id, "processK8sSecretDeleteQueue: Removing safe managed linked k8s secrets is disabled")
+	}
+}
+
+// deleteSecretFromKubernetes deletes a given SecretStored entity from a Kubernetes cluster.
+// It handles the process of configuring a Kubernetes client, determining the appropriate
+// secret name, and deleting the secret in the specified namespace.
+func deleteSecretFromKubernetes(secret entity.SecretStored, errChan chan error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		errChan <- errors.Wrap(err, "could not get in-cluster config for k8s client"+err.Error())
+		return
+	}
+
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		errChan <- errors.Wrap(err, "could not create k8s client")
+		return
+	}
+
+	k8sSecretName := env.SafeSecretNamePrefix() + secret.Name
+	// If the secret has k8s: prefix, then do not append a prefix; use the name
+	// as is.
+	if strings.HasPrefix(secret.Name, env.StoreWorkloadAsK8sSecretPrefix()) {
+		k8sSecretName = strings.TrimPrefix(
+			secret.Name, env.StoreWorkloadAsK8sSecretPrefix(),
+		)
+	}
+
+	namespaces := secret.Meta.Namespaces
+	for i, ns := range namespaces {
+		if ns == "" {
+			namespaces[i] = "default"
+		}
+
+		// Delete the Secret in the cluster with a backoff. If the secret is not found, it is a no-op.
+		err = backoff.RetryFixed(
+			ns,
+			func() error {
+				// First, try to get the existing secret
+				_, err := clientSet.CoreV1().Secrets(ns).Get(
+					context.Background(),
+					k8sSecretName,
+					metaV1.GetOptions{},
+				)
+				if kErrors.IsNotFound(err) {
+					// Secret is not found in the cluster. No need to call delete.
+					return nil
+				}
+
+				err = clientSet.CoreV1().Secrets(ns).Delete(
+					context.Background(),
+					k8sSecretName,
+					metaV1.DeleteOptions{},
+				)
+
+				return err
+			},
+		)
+
+		if err != nil {
+			errChan <- err
+		}
+	}
 }

--- a/core/env/safe.go
+++ b/core/env/safe.go
@@ -132,6 +132,23 @@ func SafeK8sSecretDeleteBufferSize() int {
 	return l
 }
 
+// SafeRemoveLinkedK8sSecrets returns a boolean indicating whether VSecM Safe
+// should delete linked Kubernetes secrets when as safe managed secret is deleted.
+//
+// The removal of linked Kubernetes secrets is determined by the environment variable
+// VSECM_SAFE_REMOVE_LINKED_K8S_SECRETS.
+//
+// If the environment variable is not set or its value is not "true",
+// the function returns false. Otherwise, the function returns true.
+func SafeRemoveLinkedK8sSecrets() bool {
+	p := strings.ToLower(os.Getenv("VSECM_SAFE_REMOVE_LINKED_K8S_SECRETS"))
+	if p == "" {
+		return false
+	}
+
+	return p == "true"
+}
+
 // SafeFipsCompliant returns a boolean indicating whether VSecM Safe should run in
 // FIPS compliant mode. Note that this is not a guarantee that VSecM Safe will
 // run in FIPS compliant mode, as it depends on the underlying base image.

--- a/core/env/safe_test.go
+++ b/core/env/safe_test.go
@@ -231,6 +231,70 @@ func TestSafeK8sSecretDeleteBufferSize(t *testing.T) {
 	}
 }
 
+func TestSafeRemoveLinkedK8sSecrets(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func() error
+		cleanup func() error
+		want    bool
+	}{
+		{
+			name: "default_safe_remove_linked_k8s_secrets",
+			want: false,
+		},
+		{
+			name: "safe_remove_linked_k8s_secrets_from_env_true",
+			setup: func() error {
+				return os.Setenv("VSECM_SAFE_REMOVE_LINKED_K8S_SECRETS", "true")
+			},
+			cleanup: func() error {
+				return os.Unsetenv("VSECM_SAFE_REMOVE_LINKED_K8S_SECRETS")
+			},
+			want: true,
+		},
+		{
+			name: "safe_remove_linked_k8s_secrets_from_env_false",
+			setup: func() error {
+				return os.Setenv("VSECM_SAFE_REMOVE_LINKED_K8S_SECRETS", "false")
+			},
+			cleanup: func() error {
+				return os.Unsetenv("VSECM_SAFE_REMOVE_LINKED_K8S_SECRETS")
+			},
+			want: false,
+		},
+		{
+			name: "invalid_safe_remove_linked_k8s_secrets_from_env",
+			setup: func() error {
+				return os.Setenv("VSECM_SAFE_REMOVE_LINKED_K8S_SECRETS", "test")
+			},
+			cleanup: func() error {
+				return os.Unsetenv("VSECM_SAFE_REMOVE_LINKED_K8S_SECRETS")
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				if err := tt.setup(); err != nil {
+					t.Errorf("SafeRemoveLinkedK8sSecrets() = failed to setup, with error: %+v", err)
+				}
+			}
+			defer func() {
+				if tt.cleanup != nil {
+					if err := tt.cleanup(); err != nil {
+						t.Errorf("SafeRemoveLinkedK8sSecrets() = failed to cleanup, with error: %+v", err)
+					}
+				}
+			}()
+			if got := SafeRemoveLinkedK8sSecrets(); got != tt.want {
+				t.Errorf("SafeRemoveLinkedK8sSecrets() = %v, want %v", got, tt.want)
+			}
+		},
+		)
+	}
+}
+
 func TestSafeFipsCompliant(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
# Delete safe-managed k8s secrets #511

## Description

This PR introduces a new feature of deleting the associated kubernetes secrets if it's a safe-managed one. User can enable this feature by setting the “VSECM_SAFE_REMOVE_LINKED_K8S_SECRETS” env variable to true.

## Changes

List the major changes you have made in bullet points:

- **app/safe/cmd/main.go:** to print new env variable
- **app/safe/internal/state/secret-queue-k8s-delete.go:** to implement deletion process. 
    - Each queue job handled in a new goroutine.
    - Each deletion process uses fixed backoff strategy.
    - If the k8s secret not found for deletion process is no-op and it does not return an error.
- **core/env/safe.go:** to get the `VSECM_SAFE_REMOVE_LINKED_K8S_SECRETS` env variable

## Test Policy Compliance

- [x] I have added or updated unit tests for my changes.
- [x] I have included integration tests where applicable.
- [x] All new and existing tests pass successfully.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

- [x] I have made corresponding changes to the documentation (if applicable).
- [x] I have updated any relevant READMEs or wiki pages.

## Checklist

Before you submit this PR, please make sure:
- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project’s license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project’s license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
