### PR TITLE
Enable VSecM Sentinel Init Command to Wait Until VSecM Safe is Healthy

### DIFF
--- a/app/keygen/cmd/decrypt.go
+++ b/app/keygen/cmd/decrypt.go
@@ -37,7 +37,7 @@ func rootKeyTriplet(content string) (string, string, string) {
 }
 
 func keys() (string, string, string) {
-	p := env.KeyGenRootKeyPath()
+	p := env.RootKeyPathForKeyGen()
 
 	content, err := os.ReadFile(p)
 	if err != nil {
@@ -77,7 +77,7 @@ func decrypt(value []byte, algorithm crypto.Algorithm) (string, error) {
 }
 
 func secrets() entity.SecretStringTimeListResponse {
-	p := env.KeyGenExportedSecretPath()
+	p := env.ExportedSecretPathForKeyGen()
 
 	content, err := os.ReadFile(p)
 	if err != nil {

--- a/app/safe/internal/server/route/internal/extract/extract.go
+++ b/app/safe/internal/server/route/internal/extract/extract.go
@@ -20,7 +20,7 @@ import (
 )
 
 func WorkloadIDAndParts(spiffeid string) (string, []string) {
-	tmp := strings.Replace(spiffeid, env.WorkloadSpiffeIdPrefix(), "", 1)
+	tmp := strings.Replace(spiffeid, env.SpiffeIdPrefixForWorkload(), "", 1)
 	parts := strings.Split(tmp, "/")
 	if len(parts) > 0 {
 		return parts[0], parts

--- a/app/safe/internal/server/route/list/impl.go
+++ b/app/safe/internal/server/route/list/impl.go
@@ -61,7 +61,7 @@ func doList(cid string, w http.ResponseWriter, r *http.Request,
 
 	log.TraceLn(&cid, "List: after defer")
 
-	tmp := strings.Replace(spiffeid, env.SentinelSpiffeIdPrefix(), "", 1)
+	tmp := strings.Replace(spiffeid, env.SpiffeIdPrefixForSentinel(), "", 1)
 	parts := strings.Split(tmp, "/")
 
 	if len(parts) == 0 {

--- a/app/sentinel/busywait/initialization/run.go
+++ b/app/sentinel/busywait/initialization/run.go
@@ -58,8 +58,7 @@ func RunInitCommands(ctx context.Context) {
 	src, acquired := spiffe.AcquireSourceForSentinel(ctx)
 
 	if !acquired {
-		// TODO: This should be configurable.
-		timeout := 300 * time.Second
+		timeout := env.InitCommandRunnerWaitTimeoutForSentinel()
 
 		timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()

--- a/app/sentinel/internal/safe/post.go
+++ b/app/sentinel/internal/safe/post.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/vmware-tanzu/secrets-manager/core/spiffe"
 	"io"
 	"net/http"
 	"net/url"
@@ -204,7 +205,7 @@ func PostInitializationComplete(parentContext context.Context) {
 	proceedChan := make(chan bool)
 
 	go func() {
-		source, proceed := acquireSource(ctxWithTimeout)
+		source, proceed := spiffe.AcquireSourceForSentinel(ctxWithTimeout)
 		sourceChan <- source
 		proceedChan <- proceed
 	}()
@@ -276,7 +277,7 @@ func Post(parentContext context.Context,
 	proceedChan := make(chan bool)
 
 	go func() {
-		source, proceed := acquireSource(ctxWithTimeout)
+		source, proceed := spiffe.AcquireSourceForSentinel(ctxWithTimeout)
 		sourceChan <- source
 		proceedChan <- proceed
 	}()

--- a/core/env/init.go
+++ b/core/env/init.go
@@ -16,12 +16,12 @@ import (
 	"time"
 )
 
-// InitContainerPollInterval returns the time interval between each poll in the
+// PollIntervalForInitContainer returns the time interval between each poll in the
 // Watch function. The interval is specified in milliseconds as the
 // VSECM_INIT_CONTAINER_POLL_INTERVAL environment variable.  If the environment
 // variable is not set or is not a valid integer value, the function returns the
 // default interval of 5000 milliseconds.
-func InitContainerPollInterval() time.Duration {
+func PollIntervalForInitContainer() time.Duration {
 	p := os.Getenv("VSECM_INIT_CONTAINER_POLL_INTERVAL")
 	if p == "" {
 		p = "5000"

--- a/core/env/init_test.go
+++ b/core/env/init_test.go
@@ -53,18 +53,18 @@ func TestInitContainerPollInterval(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setup != nil {
 				if err := tt.setup(); err != nil {
-					t.Errorf("InitContainerPollInterval() = failed to setup with error: %+v", err)
+					t.Errorf("PollIntervalForInitContainer() = failed to setup with error: %+v", err)
 				}
 			}
 			defer func() {
 				if tt.cleanup != nil {
 					if err := tt.cleanup(); err != nil {
-						t.Errorf("InitContainerPollInterval() = failed to cleanup with error: %+v", err)
+						t.Errorf("PollIntervalForInitContainer() = failed to cleanup with error: %+v", err)
 					}
 				}
 			}()
-			if got := InitContainerPollInterval(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("InitContainerPollInterval() = %v, want %v", got, tt.want)
+			if got := PollIntervalForInitContainer(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PollIntervalForInitContainer() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/core/env/keygen.go
+++ b/core/env/keygen.go
@@ -4,7 +4,7 @@ import (
 	"os"
 )
 
-// KeyGenRootKeyPath returns the root key path. Root key is used to decrypt
+// RootKeyPathForKeyGen returns the root key path. Root key is used to decrypt
 // VSecM-encrypted secrets.
 // It reads the environment variable VSECM_KEYGEN_ROOT_KEY_PATH to determine
 // the path.
@@ -13,7 +13,7 @@ import (
 // Returns:
 //
 //	string: The path to the root key.
-func KeyGenRootKeyPath() string {
+func RootKeyPathForKeyGen() string {
 	p := os.Getenv("VSECM_KEYGEN_ROOT_KEY_PATH")
 	if p == "" {
 		return "/opt/vsecm/keys.txt"
@@ -21,7 +21,7 @@ func KeyGenRootKeyPath() string {
 	return p
 }
 
-// KeyGenExportedSecretPath returns the path where the exported secrets are stored.
+// ExportedSecretPathForKeyGen returns the path where the exported secrets are stored.
 // It reads the environment variable VSECM_KEYGEN_EXPORTED_SECRET_PATH to determine
 // the path.
 // If the environment variable is not set, it defaults to "/opt/vsecm/secrets.json".
@@ -29,7 +29,7 @@ func KeyGenRootKeyPath() string {
 // Returns:
 //
 //	string: The path to the exported secrets.
-func KeyGenExportedSecretPath() string {
+func ExportedSecretPathForKeyGen() string {
 	p := os.Getenv("VSECM_KEYGEN_EXPORTED_SECRET_PATH")
 	if p == "" {
 		return "/opt/vsecm/secrets.json"

--- a/core/env/poll.go
+++ b/core/env/poll.go
@@ -16,10 +16,10 @@ import (
 	"time"
 )
 
-// SidecarMaxPollInterval returns the maximum interval for polling by the
+// MaxPollIntervalForSidecar returns the maximum interval for polling by the
 // sidecar process. The value is read from the environment variable
 // `VSECM_SIDECAR_MAX_POLL_INTERVAL` or returns 300000 milliseconds as default.
-func SidecarMaxPollInterval() time.Duration {
+func MaxPollIntervalForSidecar() time.Duration {
 	p := os.Getenv("VSECM_SIDECAR_MAX_POLL_INTERVAL")
 	if p == "" {
 		p = "300000"
@@ -31,11 +31,11 @@ func SidecarMaxPollInterval() time.Duration {
 	return time.Duration(i) * time.Millisecond
 }
 
-// SidecarExponentialBackoffMultiplier returns the multiplier for exponential
+// ExponentialBackoffMultiplierForSidecar returns the multiplier for exponential
 // backoff by the sidecar process.
 // The value is read from the environment variable
 // `VSECM_SIDECAR_EXPONENTIAL_BACKOFF_MULTIPLIER` or returns 2 as default.
-func SidecarExponentialBackoffMultiplier() int64 {
+func ExponentialBackoffMultiplierForSidecar() int64 {
 	p := os.Getenv("VSECM_SIDECAR_EXPONENTIAL_BACKOFF_MULTIPLIER")
 	if p == "" {
 		p = "2"
@@ -47,10 +47,10 @@ func SidecarExponentialBackoffMultiplier() int64 {
 	return i
 }
 
-// SidecarSuccessThreshold returns the number of consecutive successful
+// SuccessThresholdForSidecar returns the number of consecutive successful
 // polls before reducing the interval. The value is read from the environment
 // variable `VSECM_SIDECAR_SUCCESS_THRESHOLD` or returns 3 as default.
-func SidecarSuccessThreshold() int64 {
+func SuccessThresholdForSidecar() int64 {
 	p := os.Getenv("VSECM_SIDECAR_SUCCESS_THRESHOLD")
 	if p == "" {
 		p = "3"
@@ -62,10 +62,10 @@ func SidecarSuccessThreshold() int64 {
 	return i
 }
 
-// SidecarErrorThreshold returns the number of consecutive failed polls
+// ErrorThresholdForSidecar returns the number of consecutive failed polls
 // before increasing the interval. The value is read from the environment
 // variable `VSECM_SIDECAR_ERROR_THRESHOLD` or returns 2 as default.
-func SidecarErrorThreshold() int64 {
+func ErrorThresholdForSidecar() int64 {
 	p := os.Getenv("VSECM_SIDECAR_ERROR_THRESHOLD")
 	if p == "" {
 		p = "2"
@@ -77,11 +77,11 @@ func SidecarErrorThreshold() int64 {
 	return i
 }
 
-// SidecarPollInterval returns the polling interval for sentry in time.Duration
+// PollIntervalForSidecar returns the polling interval for sentry in time.Duration
 // The interval is determined by the VSECM_SIDECAR_POLL_INTERVAL environment
 // variable, with a default value of 20000 milliseconds if the variable is not
 // set or if there is an error in parsing the value.
-func SidecarPollInterval() time.Duration {
+func PollIntervalForSidecar() time.Duration {
 	p := os.Getenv("VSECM_SIDECAR_POLL_INTERVAL")
 	if p == "" {
 		p = "20000"

--- a/core/env/poll_test.go
+++ b/core/env/poll_test.go
@@ -53,18 +53,18 @@ func TestSidecarMaxPollInterval(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setup != nil {
 				if err := tt.setup(); err != nil {
-					t.Errorf("SidecarMaxPollInterval() = failed to setup, with error: %+v", err)
+					t.Errorf("MaxPollIntervalForSidecar() = failed to setup, with error: %+v", err)
 				}
 			}
 			defer func() {
 				if tt.cleanup != nil {
 					if err := tt.cleanup(); err != nil {
-						t.Errorf("SidecarMaxPollInterval() = failed to cleanup, with error: %+v", err)
+						t.Errorf("MaxPollIntervalForSidecar() = failed to cleanup, with error: %+v", err)
 					}
 				}
 			}()
-			if got := SidecarMaxPollInterval(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SidecarMaxPollInterval() = %v, want %v", got, tt.want)
+			if got := MaxPollIntervalForSidecar(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MaxPollIntervalForSidecar() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -106,18 +106,18 @@ func TestSidecarExponentialBackoffMultiplier(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setup != nil {
 				if err := tt.setup(); err != nil {
-					t.Errorf("SidecarExponentialBackoffMultiplier() = failed to setup, with error: %+v", err)
+					t.Errorf("ExponentialBackoffMultiplierForSidecar() = failed to setup, with error: %+v", err)
 				}
 			}
 			defer func() {
 				if tt.cleanup != nil {
 					if err := tt.cleanup(); err != nil {
-						t.Errorf("SidecarExponentialBackoffMultiplier() = failed to cleanup, with error: %+v", err)
+						t.Errorf("ExponentialBackoffMultiplierForSidecar() = failed to cleanup, with error: %+v", err)
 					}
 				}
 			}()
-			if got := SidecarExponentialBackoffMultiplier(); got != tt.want {
-				t.Errorf("SidecarExponentialBackoffMultiplier() = %v, want %v", got, tt.want)
+			if got := ExponentialBackoffMultiplierForSidecar(); got != tt.want {
+				t.Errorf("ExponentialBackoffMultiplierForSidecar() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -159,18 +159,18 @@ func TestSidecarSuccessThreshold(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setup != nil {
 				if err := tt.setup(); err != nil {
-					t.Errorf("SidecarSuccessThreshold() = failed to setup, with error: %+v", err)
+					t.Errorf("SuccessThresholdForSidecar() = failed to setup, with error: %+v", err)
 				}
 			}
 			defer func() {
 				if tt.cleanup != nil {
 					if err := tt.cleanup(); err != nil {
-						t.Errorf("SidecarSuccessThreshold() = failed to cleanup, with error: %+v", err)
+						t.Errorf("SuccessThresholdForSidecar() = failed to cleanup, with error: %+v", err)
 					}
 				}
 			}()
-			if got := SidecarSuccessThreshold(); got != tt.want {
-				t.Errorf("SidecarSuccessThreshold() = %v, want %v", got, tt.want)
+			if got := SuccessThresholdForSidecar(); got != tt.want {
+				t.Errorf("SuccessThresholdForSidecar() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -212,18 +212,18 @@ func TestSidecarErrorThreshold(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setup != nil {
 				if err := tt.setup(); err != nil {
-					t.Errorf("SidecarErrorThreshold() = failed to setup, with error: %+v", err)
+					t.Errorf("ErrorThresholdForSidecar() = failed to setup, with error: %+v", err)
 				}
 			}
 			defer func() {
 				if tt.cleanup != nil {
 					if err := tt.cleanup(); err != nil {
-						t.Errorf("SidecarErrorThreshold() = failed to cleanup, with error: %+v", err)
+						t.Errorf("ErrorThresholdForSidecar() = failed to cleanup, with error: %+v", err)
 					}
 				}
 			}()
-			if got := SidecarErrorThreshold(); got != tt.want {
-				t.Errorf("SidecarErrorThreshold() = %v, want %v", got, tt.want)
+			if got := ErrorThresholdForSidecar(); got != tt.want {
+				t.Errorf("ErrorThresholdForSidecar() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -265,18 +265,18 @@ func TestSidecarPollInterval(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setup != nil {
 				if err := tt.setup(); err != nil {
-					t.Errorf("SidecarPollInterval() = failed to setup, with error: %+v", err)
+					t.Errorf("PollIntervalForSidecar() = failed to setup, with error: %+v", err)
 				}
 			}
 			defer func() {
 				if tt.cleanup != nil {
 					if err := tt.cleanup(); err != nil {
-						t.Errorf("SidecarPollInterval() = failed to cleanup, with error: %+v", err)
+						t.Errorf("PollIntervalForSidecar() = failed to cleanup, with error: %+v", err)
 					}
 				}
 			}()
-			if got := SidecarPollInterval(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SidecarPollInterval() = %v, want %v", got, tt.want)
+			if got := PollIntervalForSidecar(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PollIntervalForSidecar() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/core/env/sentinel.go
+++ b/core/env/sentinel.go
@@ -12,7 +12,7 @@ package env
 
 import "os"
 
-// SentinelInitCommandPath returns the path to the initialization commands file
+// InitCommandPathForSentinel returns the path to the initialization commands file
 // for VSecM Sentinel.
 //
 // It checks for an environment variable "VSECM_SENTINEL_INIT_COMMAND_PATH" and
@@ -22,7 +22,7 @@ import "os"
 // Returns:
 //
 //	string: The path to the Sentinel initialization commands file.
-func SentinelInitCommandPath() string {
+func InitCommandPathForSentinel() string {
 	p := os.Getenv("VSECM_SENTINEL_INIT_COMMAND_PATH")
 	if p == "" {
 		p = "/opt/vsecm-sentinel/init/data"
@@ -30,7 +30,7 @@ func SentinelInitCommandPath() string {
 	return p
 }
 
-// SentinelInitCommandTombstonePath returns the path for the VSecM Sentinel
+// InitCommandTombstonePathForSentinel returns the path for the VSecM Sentinel
 // initialization command tombstone file.
 //
 // It looks for the environment variable "VSECM_SENTINEL_INIT_COMMAND_TOMBSTONE_PATH"
@@ -43,7 +43,7 @@ func SentinelInitCommandPath() string {
 // Returns:
 //
 //	string: The path to the Sentinel initialization command tombstone.
-func SentinelInitCommandTombstonePath() string {
+func InitCommandTombstonePathForSentinel() string {
 	p := os.Getenv("VSECM_SENTINEL_INIT_COMMAND_TOMBSTONE_PATH")
 	if p == "" {
 		p = "/opt/vsecm-sentinel/tombstone/init"

--- a/core/env/sentinel.go
+++ b/core/env/sentinel.go
@@ -10,7 +10,11 @@
 
 package env
 
-import "os"
+import (
+	"os"
+	"strconv"
+	"time"
+)
 
 // InitCommandPathForSentinel returns the path to the initialization commands file
 // for VSecM Sentinel.
@@ -49,4 +53,28 @@ func InitCommandTombstonePathForSentinel() string {
 		p = "/opt/vsecm-sentinel/tombstone/init"
 	}
 	return p
+}
+
+// InitCommandRunnerWaitTimeoutForSentinel initializes and returns the timeout
+// duration for waiting for Sentinel to acquire an SVID.
+//
+// If the environment variable "VSECM_SENTINEL_INIT_COMMAND_RUNNER_WAIT_TIMEOUT"
+// is set and valid, it uses the value provided by the environment variable as
+// the timeout duration.
+// If the environment variable is not set or invalid, a default timeout of
+// 300,000 milliseconds (5 minutes)
+//
+// Returns:
+//
+//	time.Duration: The max time duration that the Sentinel wiil wait for an SVID.
+func InitCommandRunnerWaitTimeoutForSentinel() time.Duration {
+	p := os.Getenv("VSECM_SENTINEL_INIT_COMMAND_RUNNER_WAIT_TIMEOUT")
+	if p == "" {
+		p = "300000"
+	}
+	i, err := strconv.ParseInt(p, 10, 32)
+	if err != nil {
+		return 300000 * time.Millisecond
+	}
+	return time.Duration(i) * time.Millisecond
 }

--- a/core/env/sidecar.go
+++ b/core/env/sidecar.go
@@ -12,10 +12,10 @@ package env
 
 import "os"
 
-// SidecarSecretsPath returns the path to the secrets file used by the sidecar.
+// SecretsPathForSidecar returns the path to the secrets file used by the sidecar.
 // The path is determined by the VSECM_SIDECAR_SECRETS_PATH environment variable,
 // with a default value of "/opt/vsecm/secrets.json" if the variable is not set.
-func SidecarSecretsPath() string {
+func SecretsPathForSidecar() string {
 	p := os.Getenv("VSECM_SIDECAR_SECRETS_PATH")
 	if p == "" {
 		p = "/opt/vsecm/secrets.json"

--- a/core/env/sidecar_test.go
+++ b/core/env/sidecar_test.go
@@ -41,18 +41,18 @@ func TestSidecarSecretsPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setup != nil {
 				if err := tt.setup(); err != nil {
-					t.Errorf("SidecarSecretsPath() = failed to setup, with error: %+v", err)
+					t.Errorf("SecretsPathForSidecar() = failed to setup, with error: %+v", err)
 				}
 			}
 			defer func() {
 				if tt.cleanup != nil {
 					if err := tt.cleanup(); err != nil {
-						t.Errorf("SidecarSecretsPath() = failed to cleanup, with error: %+v", err)
+						t.Errorf("SecretsPathForSidecar() = failed to cleanup, with error: %+v", err)
 					}
 				}
 			}()
-			if got := SidecarSecretsPath(); got != tt.want {
-				t.Errorf("SidecarSecretsPath() = %v, want %v", got, tt.want)
+			if got := SecretsPathForSidecar(); got != tt.want {
+				t.Errorf("SecretsPathForSidecar() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/core/env/spiffeid.go
+++ b/core/env/spiffeid.go
@@ -12,11 +12,11 @@ package env
 
 import "os"
 
-// SentinelSpiffeIdPrefix returns the prefix for the Safe SPIFFE ID.
+// SpiffeIdPrefixForSentinel returns the prefix for the Safe SPIFFE ID.
 // The prefix is obtained from the environment variable
 // VSECM_SENTINEL_SPIFFEID_PREFIX. If the variable is not set, the default prefix is
 // used.
-func SentinelSpiffeIdPrefix() string {
+func SpiffeIdPrefixForSentinel() string {
 	p := os.Getenv("VSECM_SENTINEL_SPIFFEID_PREFIX")
 	if p == "" {
 		p = "spiffe://vsecm.com/workload/vsecm-sentinel/ns/vsecm-system/sa/vsecm-sentinel/n/"
@@ -36,10 +36,10 @@ func SpiffeIdPrefixForSafe() string {
 	return p
 }
 
-// WorkloadSpiffeIdPrefix returns the prefix for the WorkloadId’s SPIFFE ID.
+// SpiffeIdPrefixForWorkload returns the prefix for the WorkloadId’s SPIFFE ID.
 // The prefix is obtained from the environment variable VSECM_WORKLOAD_SPIFFEID_PREFIX.
 // If the variable is not set, the default prefix is used.
-func WorkloadSpiffeIdPrefix() string {
+func SpiffeIdPrefixForWorkload() string {
 	p := os.Getenv("VSECM_WORKLOAD_SPIFFEID_PREFIX")
 	if p == "" {
 		p = "spiffe://vsecm.com/workload/"

--- a/core/env/spiffeid_test.go
+++ b/core/env/spiffeid_test.go
@@ -41,18 +41,18 @@ func TestSentinelSpiffeIdPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setup != nil {
 				if err := tt.setup(); err != nil {
-					t.Errorf("SentinelSpiffeIdPrefix() = failed to setup, with error: %+v", err)
+					t.Errorf("SpiffeIdPrefixForSentinel() = failed to setup, with error: %+v", err)
 				}
 			}
 			defer func() {
 				if tt.cleanup != nil {
 					if err := tt.cleanup(); err != nil {
-						t.Errorf("SentinelSpiffeIdPrefix() = failed to cleanup, with error: %+v", err)
+						t.Errorf("SpiffeIdPrefixForSentinel() = failed to cleanup, with error: %+v", err)
 					}
 				}
 			}()
-			if got := SentinelSpiffeIdPrefix(); got != tt.want {
-				t.Errorf("SentinelSpiffeIdPrefix() = %v, want %v", got, tt.want)
+			if got := SpiffeIdPrefixForSentinel(); got != tt.want {
+				t.Errorf("SpiffeIdPrefixForSentinel() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -127,18 +127,18 @@ func TestWorkloadSpiffeIdPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setup != nil {
 				if err := tt.setup(); err != nil {
-					t.Errorf("WorkloadSpiffeIdPrefix() = failed to setup, with error: %+v", err)
+					t.Errorf("SpiffeIdPrefixForWorkload() = failed to setup, with error: %+v", err)
 				}
 			}
 			defer func() {
 				if tt.cleanup != nil {
 					if err := tt.cleanup(); err != nil {
-						t.Errorf("WorkloadSpiffeIdPrefix() = failed to cleanup, with error: %+v", err)
+						t.Errorf("SpiffeIdPrefixForWorkload() = failed to cleanup, with error: %+v", err)
 					}
 				}
 			}()
-			if got := WorkloadSpiffeIdPrefix(); got != tt.want {
-				t.Errorf("WorkloadSpiffeIdPrefix() = %v, want %v", got, tt.want)
+			if got := SpiffeIdPrefixForWorkload(); got != tt.want {
+				t.Errorf("SpiffeIdPrefixForWorkload() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/core/spiffe/spiffe.go
+++ b/core/spiffe/spiffe.go
@@ -1,0 +1,83 @@
+package spiffe
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"github.com/vmware-tanzu/secrets-manager/core/env"
+	log "github.com/vmware-tanzu/secrets-manager/core/log/std"
+	"github.com/vmware-tanzu/secrets-manager/core/validation"
+)
+
+// AcquireSourceForSentinel initiates an asynchronous operation to obtain an
+// X509Source from the SPIFFE workload API, using the context for cancellation
+// and a correlation ID for logging purposes.
+//
+// It attempts to create a new X509Source configured with the SPIRE server address
+// from the environment, fetches the X509SVID from the source, and validates the
+// SVID against a known VSecM Sentinel value to ensure the caller is operating
+// within a trusted environment.
+//
+// Parameters:
+//   - ctx: A context.Context object used for cancellation and to carry metadata
+//     across API boundaries, including a correlation ID for tracking the
+//     operation in logs.
+//
+// Returns:
+//   - A pointer to a workloadapi.X509Source object if the source is successfully
+//     acquired and validated. This object can be used to obtain X.509 SVIDs
+//     for secure communication.
+//   - A boolean flag indicating whether the source was successfully acquired
+//     (true) or not (false). If false, the source pointer will be nil.
+func AcquireSourceForSentinel(ctx context.Context) (*workloadapi.X509Source, bool) {
+	resultChan := make(chan *workloadapi.X509Source)
+	errorChan := make(chan error)
+
+	cid := ctx.Value("correlationId").(*string)
+
+	go func() {
+		source, err := workloadapi.NewX509Source(
+			ctx, workloadapi.WithClientOptions(
+				workloadapi.WithAddr(env.SpiffeSocketUrl()),
+			),
+		)
+
+		if err != nil {
+			errorChan <- err
+			return
+		}
+
+		svid, err := source.GetX509SVID()
+		if err != nil {
+			log.ErrorLn(cid,
+				"acquireSource: I am having trouble fetching my identity from SPIRE.")
+			log.ErrorLn(cid,
+				"acquireSource: I won’t proceed until you put me in a secured container.")
+			errorChan <- err
+			return
+		}
+
+		// Make sure that the binary is enclosed in a Pod that we trust.
+		if !validation.IsSentinel(svid.ID.String()) {
+			log.ErrorLn(cid,
+				"acquireSource: I don’t know you, and it’s crazy: '"+svid.ID.String()+"'")
+			log.ErrorLn(cid,
+				"acquireSource: `safe` can only run from within the Sentinel container.")
+			errorChan <- errors.New("acquireSource: I don’t know you, and it’s crazy: '" + svid.ID.String() + "'")
+			return
+		}
+
+		resultChan <- source
+	}()
+
+	select {
+	case source := <-resultChan:
+		return source, true
+	case err := <-errorChan:
+		log.ErrorLn(cid, "acquireSource: I cannot execute command because I cannot talk to SPIRE.", err.Error())
+		return nil, false
+	case <-ctx.Done():
+		log.ErrorLn(cid, "acquireSource: Operation was cancelled.")
+		return nil, false
+	}
+}

--- a/core/validation/validation.go
+++ b/core/validation/validation.go
@@ -16,9 +16,9 @@ import (
 )
 
 // IsSentinel returns true if the given SPIFFEID is a Sentinel ID.
-// It does this by checking if the SPIFFEID has the SentinelSpiffeIdPrefix as its prefix.
+// It does this by checking if the SPIFFEID has the SpiffeIdPrefixForSentinel as its prefix.
 func IsSentinel(spiffeid string) bool {
-	return strings.HasPrefix(spiffeid, env.SentinelSpiffeIdPrefix())
+	return strings.HasPrefix(spiffeid, env.SpiffeIdPrefixForSentinel())
 }
 
 // IsSafe returns true if the given SPIFFEID is a Safe ID.
@@ -28,7 +28,7 @@ func IsSafe(spiffeid string) bool {
 }
 
 // IsWorkload returns true if the given SPIFFEID is a WorkloadId ID.
-// It does this by checking if the SPIFFEID has the WorkloadSpiffeIdPrefix as its prefix.
+// It does this by checking if the SPIFFEID has the SpiffeIdPrefixForWorkload as its prefix.
 func IsWorkload(spiffeid string) bool {
-	return strings.HasPrefix(spiffeid, env.WorkloadSpiffeIdPrefix())
+	return strings.HasPrefix(spiffeid, env.SpiffeIdPrefixForWorkload())
 }

--- a/sdk/internal/timer/timer.go
+++ b/sdk/internal/timer/timer.go
@@ -15,12 +15,12 @@ import (
 	"time"
 )
 
-var maxInterval = env.SidecarMaxPollInterval()
-var factor = env.SidecarExponentialBackoffMultiplier()
-var successThreshold = env.SidecarSuccessThreshold()
-var errorThreshold = env.SidecarErrorThreshold()
+var maxInterval = env.MaxPollIntervalForSidecar()
+var factor = env.ExponentialBackoffMultiplierForSidecar()
+var successThreshold = env.SuccessThresholdForSidecar()
+var errorThreshold = env.ErrorThresholdForSidecar()
 
-var InitialInterval = env.SidecarPollInterval()
+var InitialInterval = env.PollIntervalForSidecar()
 
 func ExponentialBackoff(
 	success bool, interval time.Duration, successCount, errorCount int64,

--- a/sdk/sentry/privates.go
+++ b/sdk/sentry/privates.go
@@ -18,7 +18,7 @@ import (
 )
 
 func saveData(data string) error {
-	path := env.SidecarSecretsPath()
+	path := env.SecretsPathForSidecar()
 
 	f, err := os.Create(path)
 	if err != nil {

--- a/sdk/startup/watch.go
+++ b/sdk/startup/watch.go
@@ -30,7 +30,7 @@ func initialized() bool {
 // If the secret exists, and it is not empty, the function exits the init
 // container with a success status code (0).
 func Watch() {
-	interval := env.InitContainerPollInterval()
+	interval := env.PollIntervalForInitContainer()
 	ticker := time.NewTicker(interval)
 
 	cid, _ := crypto.RandomString(8)


### PR DESCRIPTION
# Enable VSecM Sentinel Init Command to Wait Until VSecM Safe is Healthy

## Description

Until now, VSecM Sentinel init command stanza was executing as soon as VSecM Sentinel booted up. That resulted a race condition because it was highly likely that VSecM Safe was not ready to receive messages yet. We solved out this as introducing the `sleep:` pragma as a temporary hack:

For example `sleep:30000` would instruct VSecM Sentinel to wait 30 more seconds before running the init scripts; which saves the day but is suboptimal.

This PR makes VSecM Sentinel try acquiring an identity from the workload API (hence ensure that VSecM Safe is in good shape) before proceeding with the rest of the commands.

This still is “not” enough, but gives a very optimistic guarantee that by the time Sentinel fetches and ID, Safe will already be ready. — That is a step in the right direction.

As a follow-up PR, I’ll enable a direct health check that will call a `/health` endpoint of VSecM Safe to 100% ensure that VSecM Safe is ready before proceeding — but I wanted to get this in first.

## Changes

List the major changes you have made in bullet points:

- A loop in `RunInitCommands()` that waits for the workload API to be ready, and gives up after a timeout (default 300secs)
- Move the “acquire source” logic to “core” (instead of “internal”) as others might leverage that too.
- Method renaming for clarity and consistency.

## Test Policy Compliance

Unit tests need to be added, I haven’t added them.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

- [x] I have made corresponding changes to the documentation (if applicable).
- [x] I have updated any relevant READMEs or wiki pages.

## Checklist

Before you submit this PR, please make sure:
- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project’s license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project’s license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
