### PR TITLE
feat: Add FreeForm format handling

### DIFF
--- a/core/entity/data/v1/v1.go
+++ b/core/entity/data/v1/v1.go
@@ -78,6 +78,7 @@ var (
 	File   BackingStore = "file"
 	Json   SecretFormat = "json"
 	Yaml   SecretFormat = "yaml"
+	Raw    SecretFormat = "raw"
 )
 
 // Secret___ types are what is shown to the user.
@@ -333,6 +334,9 @@ func transform(secret SecretStored, value string) (string, error) {
 			// There is not much can be done at this point other than returning it.
 			return parsedString, nil
 		}
+	case Raw:
+		// If the format is Raw, return the parsed string as is.
+		return parsedString, nil
 	default:
 		// The program flow shall never enter here.
 		return parsedString, fmt.Errorf("unknown format: %s", secret.Meta.Format)
@@ -358,6 +362,8 @@ func transform(secret SecretStored, value string) (string, error) {
 //   - If the Meta.Format field is Yaml, then the output string is the result of
 //     transforming parsedString into Yaml if parsedString is a valid JSON,
 //     otherwise it's parsedString.
+//   - If the Meta.Format field is Raw, then the output string is simply the parsedString,
+//     without any specific format checks or transformations.
 func (secret SecretStored) Parse() (string, error) {
 	if len(secret.Values) == 0 {
 		return "", fmt.Errorf("no values found for secret %s", secret.Name)

--- a/core/entity/data/v1/v1_test.go
+++ b/core/entity/data/v1/v1_test.go
@@ -513,6 +513,20 @@ func Test_transform(t *testing.T) {
 			wantErr: false,
 			err:     nil,
 		},
+		{
+			name: "raw_format",
+			args: args{
+				value: "This is a raw text",
+				secret: SecretStored{
+					Meta: SecretMeta{
+						Format: "raw",
+					},
+				},
+			},
+			want:    "This is a raw text",
+			wantErr: false,
+			err:     nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# #226 

## Description

Added support for handling the FreeForm format in the transform function. Now, when the format is set to "FreeForm", the function directly returns the parsed string without performing any format checks or transform

## Changes

List the major changes you have made in bullet points:

- FreeForm option added transform function
- Created FreeForm global variable of type SecretFormat
- test case free_form_format added 

## Test Policy Compliance

- [x] I have added or updated unit tests for my changes.
- [x] I have included integration tests where applicable.
- [x] All new and existing tests pass successfully.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

- [x] I have made corresponding changes to the documentation (if applicable).
- [x] I have updated any relevant READMEs or wiki pages.

## Additional Comments

Include any additional comments or context about the PR here.

## Checklist

Before you submit this PR, please make sure:
- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project's license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project's license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
