### PR TITLE
Add VSecM Inspector as a Utility App

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ VSECM_EKS_REGISTRY_URL ?= "public.ecr.aws/h8y1n7y7"
 include ./makefiles/VSecMMacOs.mk
 include ./makefiles/VSecMDeploy.mk
 
+## Inspector
+include ./makefiles/VSecMInspector.mk
+
 ## Keygen
 include ./makefiles/VSecMKeyGen.mk
 

--- a/app/inspector/README.md
+++ b/app/inspector/README.md
@@ -1,0 +1,15 @@
+```text
+|   Protect your secrets, protect your sensitive data.
+:   Explore VMware Secrets Manager docs at https://vsecm.com/
+</
+<>/ keep your secrets... secret
+```
+
+## VMware Secrets Manager (*VSecM*) Inspector
+
+**VSecM Inspector** is a utility workload that you can use to inspect secrets
+assigned to workloads without shelling into the workloads.
+
+You’ll need cluster administrator privileges to use it because you’ll require
+to create a `ClusterSPIFFEID` that makes **VSecM Inspector** act on
+behalf of the workload that you are inspecting.

--- a/app/inspector/cmd/main.go
+++ b/app/inspector/cmd/main.go
@@ -1,0 +1,48 @@
+/*
+|    Protect your secrets, protect your sensitive data.
+:    Explore VMware Secrets Manager docs at https://vsecm.com/
+</
+<>/  keep your secrets... secret
+>/
+<>/' Copyright 2023-present VMware Secrets Manager contributors.
+>/'  SPDX-License-Identifier: BSD-2-Clause
+*/
+
+package main
+
+import (
+	"github.com/vmware-tanzu/secrets-manager/sdk/sentry"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	go func() {
+		// Block the process from exiting, but also be graceful and honor the
+		// termination signals that may come from the orchestrator.
+		s := make(chan os.Signal, 1)
+		signal.Notify(s, syscall.SIGINT, syscall.SIGTERM)
+		select {
+		case e := <-s:
+			println(e)
+			panic("bye cruel world!")
+		}
+	}()
+
+	// Fetch the secret from the VSecM Safe.
+	d, err := sentry.Fetch()
+	if err != nil {
+		println("Failed to fetch the secrets. Try again later.")
+		println(err.Error())
+		return
+	}
+
+	if d.Data == "" {
+		println("No secret yet... Try again later.")
+		return
+	}
+
+	// d.Data is a collection of Secrets.
+	println(d.Data)
+}

--- a/dockerfiles/example/init-container.Dockerfile
+++ b/dockerfiles/example/init-container.Dockerfile
@@ -29,9 +29,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/example .
 

--- a/dockerfiles/example/init-container.Dockerfile
+++ b/dockerfiles/example/init-container.Dockerfile
@@ -29,7 +29,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/example/multiple-secrets.Dockerfile
+++ b/dockerfiles/example/multiple-secrets.Dockerfile
@@ -32,9 +32,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/env .
 COPY --from=builder /build/sloth .

--- a/dockerfiles/example/multiple-secrets.Dockerfile
+++ b/dockerfiles/example/multiple-secrets.Dockerfile
@@ -32,7 +32,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/example/sdk.Dockerfile
+++ b/dockerfiles/example/sdk.Dockerfile
@@ -32,9 +32,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/example .
 COPY --from=builder /build/env .

--- a/dockerfiles/example/sdk.Dockerfile
+++ b/dockerfiles/example/sdk.Dockerfile
@@ -32,7 +32,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/example/sidecar.Dockerfile
+++ b/dockerfiles/example/sidecar.Dockerfile
@@ -31,9 +31,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/example .
 COPY --from=builder /build/env .

--- a/dockerfiles/example/sidecar.Dockerfile
+++ b/dockerfiles/example/sidecar.Dockerfile
@@ -31,7 +31,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/util/inspector.Dockerfile
+++ b/dockerfiles/util/inspector.Dockerfile
@@ -30,7 +30,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-safe"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/util/inspector.Dockerfile
+++ b/dockerfiles/util/inspector.Dockerfile
@@ -17,7 +17,8 @@ COPY core /build/core
 COPY vendor /build/vendor
 COPY go.mod /build/go.mod
 WORKDIR /build
-RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o vsecm-safe ./app/safe/cmd/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -o vsecm-inspector \
+    ./app/keygen/inspector/cmd/main.go
 
 # generate clean, final image for end users
 FROM gcr.io/distroless/static-debian11
@@ -33,8 +34,8 @@ LABEL "contact"=https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 
-COPY --from=builder /build/vsecm-safe .
+COPY --from=builder /build/vsecm-inspector /env
 
 # executable
-ENTRYPOINT [ "./vsecm-safe" ]
+ENTRYPOINT [ "./env" ]
 CMD [ "" ]

--- a/dockerfiles/util/keygen.Dockerfile
+++ b/dockerfiles/util/keygen.Dockerfile
@@ -32,9 +32,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-safe"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-keygen /keygen
 

--- a/dockerfiles/util/keygen.Dockerfile
+++ b/dockerfiles/util/keygen.Dockerfile
@@ -32,7 +32,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-safe"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-ist-fips/init-container.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/init-container.Dockerfile
@@ -33,7 +33,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-ist-fips/init-container.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/init-container.Dockerfile
@@ -33,9 +33,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-init-container .
 

--- a/dockerfiles/vsecm-ist-fips/safe.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/safe.Dockerfile
@@ -31,7 +31,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-safe"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-ist-fips/safe.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/safe.Dockerfile
@@ -31,9 +31,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-safe"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-safe .
 

--- a/dockerfiles/vsecm-ist-fips/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/sentinel.Dockerfile
@@ -32,9 +32,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-sentinel"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 # Copy the required binaries
 COPY --from=builder /build/safe /bin/safe

--- a/dockerfiles/vsecm-ist-fips/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/sentinel.Dockerfile
@@ -32,7 +32,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-sentinel"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-ist-fips/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/sidecar.Dockerfile
@@ -32,7 +32,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-ist-fips/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-ist-fips/sidecar.Dockerfile
@@ -32,9 +32,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-sidecar .
 

--- a/dockerfiles/vsecm-ist/init-container.Dockerfile
+++ b/dockerfiles/vsecm-ist/init-container.Dockerfile
@@ -31,7 +31,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-ist/init-container.Dockerfile
+++ b/dockerfiles/vsecm-ist/init-container.Dockerfile
@@ -31,9 +31,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-init-container .
 

--- a/dockerfiles/vsecm-ist/safe.Dockerfile
+++ b/dockerfiles/vsecm-ist/safe.Dockerfile
@@ -29,7 +29,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-safe"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-ist/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-ist/sentinel.Dockerfile
@@ -30,9 +30,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-sentinel"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 # Copy the required binaries
 COPY --from=builder /build/safe /bin/safe

--- a/dockerfiles/vsecm-ist/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-ist/sentinel.Dockerfile
@@ -30,7 +30,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-sentinel"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-ist/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-ist/sidecar.Dockerfile
@@ -29,9 +29,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-sidecar .
 

--- a/dockerfiles/vsecm-ist/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-ist/sidecar.Dockerfile
@@ -29,7 +29,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-photon-fips/init-container.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/init-container.Dockerfile
@@ -33,7 +33,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-photon-fips/init-container.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/init-container.Dockerfile
@@ -33,9 +33,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-init-container .
 

--- a/dockerfiles/vsecm-photon-fips/safe.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/safe.Dockerfile
@@ -31,7 +31,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-safe"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-photon-fips/safe.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/safe.Dockerfile
@@ -31,9 +31,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-safe"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-safe .
 

--- a/dockerfiles/vsecm-photon-fips/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/sentinel.Dockerfile
@@ -32,9 +32,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-sentinel"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 # Copy the required binaries
 COPY --from=builder /build/safe /bin/safe

--- a/dockerfiles/vsecm-photon-fips/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/sentinel.Dockerfile
@@ -32,7 +32,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-sentinel"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-photon-fips/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/sidecar.Dockerfile
@@ -31,9 +31,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-sidecar .
 

--- a/dockerfiles/vsecm-photon-fips/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-photon-fips/sidecar.Dockerfile
@@ -31,7 +31,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-photon/init-container.Dockerfile
+++ b/dockerfiles/vsecm-photon/init-container.Dockerfile
@@ -31,7 +31,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-photon/init-container.Dockerfile
+++ b/dockerfiles/vsecm-photon/init-container.Dockerfile
@@ -31,9 +31,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-init-container .
 

--- a/dockerfiles/vsecm-photon/safe.Dockerfile
+++ b/dockerfiles/vsecm-photon/safe.Dockerfile
@@ -29,9 +29,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-safe"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-safe .
 

--- a/dockerfiles/vsecm-photon/safe.Dockerfile
+++ b/dockerfiles/vsecm-photon/safe.Dockerfile
@@ -29,7 +29,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-safe"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-photon/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-photon/sentinel.Dockerfile
@@ -30,9 +30,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-sentinel"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 # Copy the required binaries
 COPY --from=builder /build/safe /bin/safe

--- a/dockerfiles/vsecm-photon/sentinel.Dockerfile
+++ b/dockerfiles/vsecm-photon/sentinel.Dockerfile
@@ -30,7 +30,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager-sentinel"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/dockerfiles/vsecm-photon/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-photon/sidecar.Dockerfile
@@ -29,9 +29,9 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"="https://vsecm.com/contact/"
-LABEL "community"="https://vsecm.com/community"
-LABEL "changelog"="https://vsecm.com/changelog"
+LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "community"="https://vsecm.com/docs/community"
+LABEL "changelog"="https://vsecm.com/docs/changelog"
 
 COPY --from=builder /build/vsecm-sidecar .
 

--- a/dockerfiles/vsecm-photon/sidecar.Dockerfile
+++ b/dockerfiles/vsecm-photon/sidecar.Dockerfile
@@ -29,7 +29,7 @@ LABEL "version"=$APP_VERSION
 LABEL "website"="https://vsecm.com/"
 LABEL "repo"="https://github.com/vmware-tanzu/secrets-manager"
 LABEL "documentation"="https://vsecm.com/"
-LABEL "contact"=https://vsecm.com/docs/contact"
+LABEL "contact"="https://vsecm.com/docs/contact"
 LABEL "community"="https://vsecm.com/docs/community"
 LABEL "changelog"="https://vsecm.com/docs/changelog"
 

--- a/makefiles/VSecMBuild.mk
+++ b/makefiles/VSecMBuild.mk
@@ -13,6 +13,8 @@ serve-docs:
 
 # Builds everything and pushes to public DockerHub registries.
 build: \
+	inspector-bundle \
+	inspector-push \
 	keygen-bundle \
 	keygen-push \
 	example-sidecar-bundle \
@@ -72,6 +74,8 @@ login-eks:
 # Builds everything and pushes to the public EKS registry.
 build-eks: \
 	login-eks \
+	inspector-bundle \
+	inspector-push-eks \
 	keygen-bundle \
 	keygen-push-eks \
 	example-sidecar-bundle \
@@ -117,6 +121,8 @@ build-eks: \
 
 # Builds everything and pushes to the local registry.
 build-local: \
+	inspector-bundle \
+	inspector-push-local \
 	keygen-bundle \
 	keygen-push-local \
 	example-sidecar-bundle \
@@ -162,6 +168,7 @@ build-local: \
 
 build-essentials-local: \
 	keygen-bundle \
+	inspector-bundle \
 	safe-bundle-ist \
 	safe-push-ist-local \
 	sidecar-bundle-ist \

--- a/makefiles/VSecMInspector.mk
+++ b/makefiles/VSecMInspector.mk
@@ -1,0 +1,29 @@
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets... secret
+# >/
+# <>/' Copyright 2023-present VMware Secrets Manager contributors.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
+
+# Packages the "Inspector" binary into a container image.
+inspector-bundle:
+	./hack/bundle.sh "vsecm-inspector" \
+		$(VERSION) "dockerfiles/util/inspector.Dockerfile"
+
+# Pushes the "Inspector" container image to the public registry.
+inspector-push:
+	./hack/push.sh "vsecm-inspector" \
+		$(VERSION) "$(VSECM_DOCKERHUB_REGISTRY_URL)/vsecm-inspector"
+
+# Pushes the "Inspector" container image to the public EKS registry.
+inspector-push-eks:
+	./hack/push.sh "vsecm-inspector" $(VERSION) \
+		"$(VSECM_EKS_REGISTRY_URL)/vsecm-inspector"
+
+# Pushes the "Inspector" container image to the local registry.
+inspector-push-local:
+	./hack/push.sh "vsecm-inspector" $(VERSION) \
+		"$(VSECM_LOCAL_REGISTRY_URL)/vsecm-inspector"


### PR DESCRIPTION
# VSecM Inspector

## Description

This PR introduces **VSecM Inspector**, an app that can inspect the secrets assigned to workloads without directly shelling into the workloads.

To use VSecM inspector, you’ll need cluster admin privileges since you’ll need to create relevant ClusterSPIFFEIDs.

## Changes

- Add dockerfiles and relevant makefiles
- (unrelated) fixed dead links in some dockerfiles

## Test Policy Compliance

- [x] I have added or updated unit tests for my changes.
- [x] I have included integration tests where applicable.
- [x] All new and existing tests pass successfully.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

I’ll add docs related to VSecM Inspector in a follow-up PR.

## Checklist

Before you submit this PR, please make sure:
- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project's license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project's license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
