### PR TITLE
🐛 fix(VSecM): made 8443 port dynamic

### DIFF
--- a/helm-charts/0.23.3/charts/safe/templates/Deployment.yaml
+++ b/helm-charts/0.23.3/charts/safe/templates/Deployment.yaml
@@ -43,7 +43,9 @@ spec:
           image: "{{ .Values.global.registry }}/{{- include "safe.repository" .}}:{{ .Values.global.images.safe.tag }}"
           imagePullPolicy: {{ .Values.global.images.safe.pullPolicy }}
           ports:
-            - containerPort: 8443
+            - containerPort: {{ .Values.service.port }}
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/eks/vsecm-distroless-fips.yaml
+++ b/k8s/0.23.3/eks/vsecm-distroless-fips.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/eks/vsecm-distroless.yaml
+++ b/k8s/0.23.3/eks/vsecm-distroless.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/eks/vsecm-photon-fips.yaml
+++ b/k8s/0.23.3/eks/vsecm-photon-fips.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/eks/vsecm-photon.yaml
+++ b/k8s/0.23.3/eks/vsecm-photon.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/local/vsecm-distroless-fips.yaml
+++ b/k8s/0.23.3/local/vsecm-distroless-fips.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/local/vsecm-distroless.yaml
+++ b/k8s/0.23.3/local/vsecm-distroless.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/local/vsecm-photon-fips.yaml
+++ b/k8s/0.23.3/local/vsecm-photon-fips.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/local/vsecm-photon.yaml
+++ b/k8s/0.23.3/local/vsecm-photon.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/remote/vsecm-distroless-fips.yaml
+++ b/k8s/0.23.3/remote/vsecm-distroless-fips.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/remote/vsecm-distroless.yaml
+++ b/k8s/0.23.3/remote/vsecm-distroless.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/remote/vsecm-photon-fips.yaml
+++ b/k8s/0.23.3/remote/vsecm-photon-fips.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket

--- a/k8s/0.23.3/remote/vsecm-photon.yaml
+++ b/k8s/0.23.3/remote/vsecm-photon.yaml
@@ -317,6 +317,8 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+              name: http
+              protocol: TCP
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket


### PR DESCRIPTION
# Update Helm Charts to Make VSecM Safe Service Port Dynamic

## Description

This PR updates VSecM helm charts to get the service port dynamically, from `values.yaml`.

## Changes

- `./helm-charts/0.23.3/charts/safe/Deployment.yaml`
- The rest of the files in the PR are autogenerated.

## Test Policy Compliance

- [x] I have added or updated unit tests for my changes.
- [x] I have included integration tests where applicable.
- [x] All new and existing tests pass successfully.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] I have updated any relevant READMEs or wiki pages.

## Additional Comments

Include any additional comments or context about the PR here.

## Checklist

Before you submit this PR, please make sure:
- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project's license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project's license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
