### PR TITLE
(feat) Remove nodeport from helm charts

### DIFF
--- a/helm-charts/0.23.3/charts/spire/templates/spire-server.yaml
+++ b/helm-charts/0.23.3/charts/spire/templates/spire-server.yaml
@@ -238,11 +238,11 @@ metadata:
   name: spire-server
   namespace: {{ .Values.global.spire.namespace }}
 spec:
-  type: NodePort
+  type: {{ .Values.service.type }}
   ports:
     - name: api
-      port: 8081
-      targetPort: 8081
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
       protocol: TCP
   selector:
     app: spire-server

--- a/helm-charts/0.23.3/charts/spire/values.yaml
+++ b/helm-charts/0.23.3/charts/spire/values.yaml
@@ -28,7 +28,6 @@ service:
   port: 8081
   annotations: {}
 
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/helm-charts/0.23.3/charts/spire/values.yaml
+++ b/helm-charts/0.23.3/charts/spire/values.yaml
@@ -22,6 +22,13 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+service:
+  # ClusterIP, NodePort, LoadBalancer
+  type: ClusterIP
+  port: 8081
+  annotations: {}
+
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/k8s/0.23.3/spire.yaml
+++ b/k8s/0.23.3/spire.yaml
@@ -443,7 +443,7 @@ metadata:
   name: spire-server
   namespace: spire-system
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - name: api
       port: 8081


### PR DESCRIPTION
Remove nodeport from helm charts.

Make SPIRE Server service port configurable, and let it default to ClusterIP instead of nodeport.