### PR TITLE
Ability to Associate the Same Random Secret to Multiple Workloads

### DIFF
--- a/app/safe/internal/server/route/receive/receive.go
+++ b/app/safe/internal/server/route/receive/receive.go
@@ -39,7 +39,7 @@ import (
 //   - cid (string): Correlation ID for operation tracing and logging.
 //   - w (http.ResponseWriter): The HTTP response writer to send back responses or
 //     errors.
-//   - r (*http.Request): The incoming HTTP request containing the keys payload.
+//   - r (*http.Request): The incoming HTTP request containing the payload.
 //   - spiffeid (string): The SPIFFE ID associated with the requester, used for
 //     authorization validation.
 func Keys(cid string, w http.ResponseWriter, r *http.Request, spiffeid string) {

--- a/app/sentinel/busywait/initialization/run.go
+++ b/app/sentinel/busywait/initialization/run.go
@@ -86,7 +86,7 @@ func RunInitCommands(ctx context.Context) {
 		return
 	}
 
-	// If we are here, then SPIFFE Workloads API is functioning as expected.
+	// If we are here, then SPIFFE Workload API is functioning as expected.
 	// We’ll do one last check to ensure Sentinel can communicate with Safe
 	// before executing the init commands.
 

--- a/app/sentinel/busywait/initialization/run.go
+++ b/app/sentinel/busywait/initialization/run.go
@@ -43,7 +43,7 @@ import (
 // 'entity.SentinelCommand' struct.
 //
 // Key commands include:
-// - workload: (w) Sets the WorkloadId field in the SentinelCommand.
+// - workload: (w) Sets the WorkloadIds field in the SentinelCommand.
 // - namespace: (n) Sets the Namespaces field.
 // - secret: (s) Sets the Secret field.
 // - transformation: (t) Sets the Template field.
@@ -224,7 +224,7 @@ dance:
 			)
 			return
 		case workload:
-			sc.WorkloadId = value
+			sc.WorkloadIds = strings.SplitN(value, itemSeparator, -1)
 		case namespace:
 			sc.Namespaces = strings.SplitN(value, itemSeparator, -1)
 		case secret:

--- a/app/sentinel/busywait/initialization/run.go
+++ b/app/sentinel/busywait/initialization/run.go
@@ -86,7 +86,7 @@ func RunInitCommands(ctx context.Context) {
 		return
 	}
 
-	// If we are here, then SPIFFE Workload API is functioning as expected.
+	// If we are here, then SPIFFE Workloads API is functioning as expected.
 	// We’ll do one last check to ensure Sentinel can communicate with Safe
 	// before executing the init commands.
 

--- a/app/sentinel/cmd/help.go
+++ b/app/sentinel/cmd/help.go
@@ -34,11 +34,12 @@ func printSecretNeeded() {
 	println("")
 }
 
-func inputValidationFailure(workload *string, encrypt *bool, inputKeys *string, secret *string, deleteSecret *bool) bool {
+func inputValidationFailure(workload *[]string, encrypt *bool, inputKeys *string,
+	secret *string, deleteSecret *bool) bool {
 
 	// You need to provide a workload name if you are not encrypting a secret,
 	// or if you are not providing input keys.
-	if *workload == "" &&
+	if len(*workload) == 0 &&
 		!*encrypt &&
 		*inputKeys == "" {
 		printWorkloadNameNeeded()

--- a/app/sentinel/cmd/main.go
+++ b/app/sentinel/cmd/main.go
@@ -40,10 +40,10 @@ func main() {
 	list := parseList(parser)
 	deleteSecret := parseDeleteSecret(parser)
 	appendSecret := parseAppendSecret(parser)
-	namespace := parseNamespaces(parser)
+	namespaces := parseNamespaces(parser)
 	inputKeys := parseInputKeys(parser)
 	backingStore := parseBackingStore(parser)
-	workloadId := parseWorkload(parser)
+	workloadIds := parseWorkload(parser)
 	secret := parseSecret(parser)
 	template := parseTemplate(parser)
 	format := parseFormat(parser)
@@ -68,11 +68,11 @@ func main() {
 		return
 	}
 
-	if *namespace == nil || len(*namespace) == 0 {
-		*namespace = []string{"default"}
+	if *namespaces == nil || len(*namespaces) == 0 {
+		*namespaces = []string{"default"}
 	}
 
-	if inputValidationFailure(workloadId, encrypt, inputKeys, secret, deleteSecret) {
+	if inputValidationFailure(workloadIds, encrypt, inputKeys, secret, deleteSecret) {
 		return
 	}
 
@@ -88,9 +88,9 @@ func main() {
 	}()
 
 	safe.Post(ctx, entity.SentinelCommand{
-		WorkloadId:   *workloadId,
+		WorkloadIds:  *workloadIds,
 		Secret:       *secret,
-		Namespaces:   *namespace,
+		Namespaces:   *namespaces,
 		BackingStore: *backingStore,
 		Template:     *template,
 		Format:       *format,

--- a/app/sentinel/cmd/parse.go
+++ b/app/sentinel/cmd/parse.go
@@ -55,8 +55,8 @@ func parseBackingStore(parser *argparse.Parser) *string {
 	})
 }
 
-func parseWorkload(parser *argparse.Parser) *string {
-	return parser.String("w", "workload", &argparse.Options{
+func parseWorkload(parser *argparse.Parser) *[]string {
+	return parser.StringList("w", "workload", &argparse.Options{
 		Required: false,
 		Help: "name of the workload (i.e. the '$name' segment of its " +
 			"ClusterSPIFFEID ('spiffe://trustDomain/workload/$name/...'))",

--- a/app/sentinel/internal/safe/get.go
+++ b/app/sentinel/internal/safe/get.go
@@ -48,7 +48,7 @@ func Check(ctx context.Context, source *workloadapi.X509Source) error {
 	cid := ctx.Value("correlationId").(*string)
 
 	if source == nil {
-		return errors.New("check: Workloads source is nil")
+		return errors.New("check: workload source is nil")
 	}
 
 	authorizer := tlsconfig.AdaptMatcher(func(id spiffeid.ID) error {

--- a/app/sentinel/internal/safe/get.go
+++ b/app/sentinel/internal/safe/get.go
@@ -48,7 +48,7 @@ func Check(ctx context.Context, source *workloadapi.X509Source) error {
 	cid := ctx.Value("correlationId").(*string)
 
 	if source == nil {
-		return errors.New("check: Workload source is nil")
+		return errors.New("check: Workloads source is nil")
 	}
 
 	authorizer := tlsconfig.AdaptMatcher(func(id spiffeid.ID) error {

--- a/app/sentinel/internal/safe/post.go
+++ b/app/sentinel/internal/safe/post.go
@@ -81,8 +81,8 @@ func newInitCompletedRequest() reqres.SentinelInitCompleteRequest {
 	return reqres.SentinelInitCompleteRequest{}
 }
 
-func newSecretUpsertRequest(workloadId, secret string, namespaces []string,
-	backingStore string, template string, format string,
+func newSecretUpsertRequest(workloadIds []string, secret string,
+	namespaces []string, backingStore string, template string, format string,
 	encrypt, appendSecret bool, notBefore string, expires string,
 ) reqres.SecretUpsertRequest {
 	bs := decideBackingStore(backingStore)
@@ -97,7 +97,7 @@ func newSecretUpsertRequest(workloadId, secret string, namespaces []string,
 	}
 
 	return reqres.SecretUpsertRequest{
-		WorkloadId:   workloadId,
+		WorkloadIds:  workloadIds,
 		BackingStore: bs,
 		Namespaces:   namespaces,
 		Template:     template,
@@ -370,7 +370,7 @@ func Post(parentContext context.Context,
 			},
 		}
 
-		sr := newSecretUpsertRequest(sc.WorkloadId, sc.Secret, sc.Namespaces,
+		sr := newSecretUpsertRequest(sc.WorkloadIds, sc.Secret, sc.Namespaces,
 			sc.BackingStore, sc.Template, sc.Format,
 			sc.Encrypt, sc.AppendSecret, sc.NotBefore, sc.Expires)
 

--- a/app/sentinel/rest/core/adapter.go
+++ b/app/sentinel/rest/core/adapter.go
@@ -21,7 +21,7 @@ import (
 )
 
 type SecretRequest struct {
-	Workload     string   `json:"workload"`
+	Workloads    []string `json:"workload"`
 	Secret       string   `json:"secret"`
 	Namespaces   []string `json:"namespaces,omitempty"`
 	UseK8s       bool     `json:"use-k8s,omitempty"`
@@ -76,14 +76,14 @@ func HandleCommandSecrets(w http.ResponseWriter, r *http.Request, req *SecretReq
 		req.Namespaces = []string{"default"}
 	}
 
-	if InvalidInput(req.Workload, req.Encrypt, req.InputKeys, req.Secret, req.Delete) {
+	if invalidInput(req.Workloads, req.Encrypt, req.InputKeys, req.Secret, req.Delete) {
 		http.Error(w, "Input Validation Failure", http.StatusInternalServerError)
 		return
 	}
 
 	responseBody, err := safe.Post(ctx, r,
 		entity.SentinelCommand{
-			WorkloadIds:  req.Workload,
+			WorkloadIds:  req.Workloads,
 			Secret:       req.Secret,
 			Namespaces:   req.Namespaces,
 			BackingStore: req.BackingStore,

--- a/app/sentinel/rest/core/adapter.go
+++ b/app/sentinel/rest/core/adapter.go
@@ -83,7 +83,7 @@ func HandleCommandSecrets(w http.ResponseWriter, r *http.Request, req *SecretReq
 
 	responseBody, err := safe.Post(ctx, r,
 		entity.SentinelCommand{
-			WorkloadId:   req.Workload,
+			WorkloadIds:  req.Workload,
 			Secret:       req.Secret,
 			Namespaces:   req.Namespaces,
 			BackingStore: req.BackingStore,

--- a/app/sentinel/rest/core/validation.go
+++ b/app/sentinel/rest/core/validation.go
@@ -10,12 +10,12 @@
 
 package core
 
-func InvalidInput(workload string, encrypt bool,
+func invalidInput(workloads []string, encrypt bool,
 	inputKeys string, secret string, deleteSecret bool) bool {
 
-	// You need to provide a workload name if you are not encrypting a secret,
+	// You need to provide a workloads name if you are not encrypting a secret,
 	// or if you are not providing input keys.
-	if workload == "" && !encrypt && inputKeys == "" {
+	if len(workloads) == 0 && !encrypt && inputKeys == "" {
 		return true
 	}
 

--- a/app/sentinel/rest/core/validation.go
+++ b/app/sentinel/rest/core/validation.go
@@ -13,9 +13,9 @@ package core
 func invalidInput(workloads []string, encrypt bool,
 	inputKeys string, secret string, deleteSecret bool) bool {
 
-	// You need to provide a workloads name if you are not encrypting a secret,
+	// You need to provide a workload collection if you are not encrypting a secret,
 	// or if you are not providing input keys.
-	if len(workloads) == 0 && !encrypt && inputKeys == "" {
+	if workloads != nil && len(workloads) == 0 && !encrypt && inputKeys == "" {
 		return true
 	}
 

--- a/app/sentinel/rest/safe/post.go
+++ b/app/sentinel/rest/safe/post.go
@@ -75,7 +75,7 @@ func newInputKeysRequest(ageSecretKey, agePublicKey, aesCipherKey string,
 	}
 }
 
-func newSecretUpsertRequest(workloadId, secret string, namespaces []string,
+func newSecretUpsertRequest(workloadIds []string, secret string, namespaces []string,
 	backingStore string, template string, format string,
 	encrypt, appendSecret bool, notBefore string, expires string,
 ) reqres.SecretUpsertRequest {
@@ -91,7 +91,7 @@ func newSecretUpsertRequest(workloadId, secret string, namespaces []string,
 	}
 
 	return reqres.SecretUpsertRequest{
-		WorkloadIds:  workloadId,
+		WorkloadIds:  workloadIds,
 		BackingStore: bs,
 		Namespaces:   namespaces,
 		Template:     template,

--- a/app/sentinel/rest/safe/post.go
+++ b/app/sentinel/rest/safe/post.go
@@ -91,7 +91,7 @@ func newSecretUpsertRequest(workloadId, secret string, namespaces []string,
 	}
 
 	return reqres.SecretUpsertRequest{
-		WorkloadId:   workloadId,
+		WorkloadIds:  workloadId,
 		BackingStore: bs,
 		Namespaces:   namespaces,
 		Template:     template,
@@ -271,7 +271,7 @@ func Post(parentContext context.Context, r *http.Request, sc entity.SentinelComm
 			},
 		}
 
-		sr := newSecretUpsertRequest(sc.WorkloadId, sc.Secret, sc.Namespaces,
+		sr := newSecretUpsertRequest(sc.WorkloadIds, sc.Secret, sc.Namespaces,
 			sc.BackingStore, sc.Template, sc.Format,
 			sc.Encrypt, sc.AppendSecret, sc.NotBefore, sc.Expires)
 

--- a/ci/test/io/io.go
+++ b/ci/test/io/io.go
@@ -22,7 +22,7 @@ func Wait(seconds time.Duration) error {
 	// This is a simplification. In a real scenario, you would check the workload's readiness more robustly.
 	println("Waiting for the workload to be ready...")
 	time.Sleep(seconds * time.Second) // Simulate waiting for readiness with a sleep.
-	println("Workload is now ready.")
+	println("Workloads is now ready.")
 	return nil
 }
 

--- a/ci/test/io/io.go
+++ b/ci/test/io/io.go
@@ -22,7 +22,7 @@ func Wait(seconds time.Duration) error {
 	// This is a simplification. In a real scenario, you would check the workload's readiness more robustly.
 	println("Waiting for the workload to be ready...")
 	time.Sleep(seconds * time.Second) // Simulate waiting for readiness with a sleep.
-	println("Workloads is now ready.")
+	println("Workload is now ready.")
 	return nil
 }
 

--- a/core/audit/audit.go
+++ b/core/audit/audit.go
@@ -52,7 +52,7 @@ func Log(e JournalEntry) {
 			e.CorrelationId,
 			"SecretDeleteRequest",
 			e.Method, e.Url, e.SpiffeId,
-			"w:'"+v.WorkloadId+"',e:'"+v.Err+"',m:'"+string(e.Event)+"'",
+			"w:'"+v.WorkloadIds+"',e:'"+v.Err+"',m:'"+string(e.Event)+"'",
 		)
 	case reqres.SecretDeleteResponse:
 		printAudit(

--- a/core/audit/audit.go
+++ b/core/audit/audit.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware-tanzu/secrets-manager/core/audit/state"
 	reqres "github.com/vmware-tanzu/secrets-manager/core/entity/reqres/safe/v1"
 	"github.com/vmware-tanzu/secrets-manager/core/log/std"
+	"strings"
 )
 
 type JournalEntry struct {
@@ -52,7 +53,7 @@ func Log(e JournalEntry) {
 			e.CorrelationId,
 			"SecretDeleteRequest",
 			e.Method, e.Url, e.SpiffeId,
-			"w:'"+v.WorkloadIds+"',e:'"+v.Err+"',m:'"+string(e.Event)+"'",
+			"w:'"+strings.Join(v.WorkloadIds, "!")+"',e:'"+v.Err+"',m:'"+string(e.Event)+"'",
 		)
 	case reqres.SecretDeleteResponse:
 		printAudit(

--- a/core/entity/data/v1/v1.go
+++ b/core/entity/data/v1/v1.go
@@ -26,7 +26,7 @@ type VSecMInternalCommand struct {
 }
 
 type SentinelCommand struct {
-	WorkloadId      string
+	WorkloadIds     []string
 	Namespaces      []string
 	Secret          string
 	Template        string

--- a/core/entity/reqres/safe/v1/v1.go
+++ b/core/entity/reqres/safe/v1/v1.go
@@ -16,7 +16,7 @@ import (
 )
 
 type SecretUpsertRequest struct {
-	WorkloadIds  []string          `json:"keys"`
+	WorkloadIds  []string          `json:"workloads"`
 	BackingStore data.BackingStore `json:"backingStore"`
 	Namespaces   []string          `json:"namespaces"`
 	Value        string            `json:"value"`
@@ -61,8 +61,8 @@ type SecretFetchResponse struct {
 }
 
 type SecretDeleteRequest struct {
-	WorkloadId string `json:"key"`
-	Err        string `json:"err,omitempty"`
+	WorkloadIds []string `json:"workloads`
+	Err         string   `json:"err,omitempty"`
 }
 
 type SecretDeleteResponse struct {

--- a/core/entity/reqres/safe/v1/v1.go
+++ b/core/entity/reqres/safe/v1/v1.go
@@ -16,7 +16,7 @@ import (
 )
 
 type SecretUpsertRequest struct {
-	WorkloadId   string            `json:"key"`
+	WorkloadIds  []string          `json:"keys"`
 	BackingStore data.BackingStore `json:"backingStore"`
 	Namespaces   []string          `json:"namespaces"`
 	Value        string            `json:"value"`

--- a/core/entity/reqres/safe/v1/v1.go
+++ b/core/entity/reqres/safe/v1/v1.go
@@ -61,7 +61,7 @@ type SecretFetchResponse struct {
 }
 
 type SecretDeleteRequest struct {
-	WorkloadIds []string `json:"workloads`
+	WorkloadIds []string `json:"workloads"`
 	Err         string   `json:"err,omitempty"`
 }
 

--- a/core/env/spiffeid.go
+++ b/core/env/spiffeid.go
@@ -36,7 +36,7 @@ func SpiffeIdPrefixForSafe() string {
 	return p
 }
 
-// SpiffeIdPrefixForWorkload returns the prefix for the Workloads's SPIFFE ID.
+// SpiffeIdPrefixForWorkload returns the prefix for the Workload's SPIFFE ID.
 // The prefix is obtained from the environment variable VSECM_WORKLOAD_SPIFFEID_PREFIX.
 // If the variable is not set, the default prefix is used.
 func SpiffeIdPrefixForWorkload() string {

--- a/core/env/spiffeid.go
+++ b/core/env/spiffeid.go
@@ -36,7 +36,7 @@ func SpiffeIdPrefixForSafe() string {
 	return p
 }
 
-// SpiffeIdPrefixForWorkload returns the prefix for the WorkloadId's SPIFFE ID.
+// SpiffeIdPrefixForWorkload returns the prefix for the Workload's SPIFFE ID.
 // The prefix is obtained from the environment variable VSECM_WORKLOAD_SPIFFEID_PREFIX.
 // If the variable is not set, the default prefix is used.
 func SpiffeIdPrefixForWorkload() string {

--- a/core/env/spiffeid.go
+++ b/core/env/spiffeid.go
@@ -36,7 +36,7 @@ func SpiffeIdPrefixForSafe() string {
 	return p
 }
 
-// SpiffeIdPrefixForWorkload returns the prefix for the Workload's SPIFFE ID.
+// SpiffeIdPrefixForWorkload returns the prefix for the Workloads's SPIFFE ID.
 // The prefix is obtained from the environment variable VSECM_WORKLOAD_SPIFFEID_PREFIX.
 // If the variable is not set, the default prefix is used.
 func SpiffeIdPrefixForWorkload() string {

--- a/core/validation/validation.go
+++ b/core/validation/validation.go
@@ -27,7 +27,7 @@ func IsSafe(spiffeid string) bool {
 	return strings.HasPrefix(spiffeid, env.SpiffeIdPrefixForSafe())
 }
 
-// IsWorkload returns true if the given SPIFFEID is a WorkloadId ID.
+// IsWorkload returns true if the given SPIFFEID is a WorkloadIds ID.
 // It does this by checking if the SPIFFEID has the SpiffeIdPrefixForWorkload as its prefix.
 func IsWorkload(spiffeid string) bool {
 	return strings.HasPrefix(spiffeid, env.SpiffeIdPrefixForWorkload())

--- a/helm-charts/0.23.3/charts/sentinel/values.yaml
+++ b/helm-charts/0.23.3/charts/sentinel/values.yaml
@@ -101,8 +101,8 @@ initCommand:
   #
   #  sleep:30001
   #  --
-  #  w:k8s:keycloak-admin-secret
-  #  n:smo-app
+  #  w:keycloak-admin-secret,keycloak-db-secret
+  #  n:smo-app,web-app
   #  s:gen:{"username":"admin-[a-z0-9]{6}","password":"[a-zA-Z0-9]{12}"}
   #  t:{"KEYCLOAK_ADMIN_USER":"{{.username}}","KEYCLOAK_ADMIN_PASSWORD":"{{.password}}"}
   #  --

--- a/sdk/sentry/fetch.go
+++ b/sdk/sentry/fetch.go
@@ -58,7 +58,7 @@ func Fetch() (reqres.SecretFetchResponse, error) {
 	)
 	if err != nil {
 		return reqres.SecretFetchResponse{}, errors.Wrap(
-			err, "Fetch: failed getting SVID Bundle from the SPIFFE WorkloadId API",
+			err, "Fetch: failed getting SVID Bundle from the SPIFFE Workload API",
 		)
 	}
 

--- a/sdk/sentry/fetch.go
+++ b/sdk/sentry/fetch.go
@@ -58,7 +58,7 @@ func Fetch() (reqres.SecretFetchResponse, error) {
 	)
 	if err != nil {
 		return reqres.SecretFetchResponse{}, errors.Wrap(
-			err, "Fetch: failed getting SVID Bundle from the SPIFFE Workload API",
+			err, "Fetch: failed getting SVID Bundle from the SPIFFE Workloads API",
 		)
 	}
 

--- a/sdk/sentry/fetch.go
+++ b/sdk/sentry/fetch.go
@@ -58,7 +58,7 @@ func Fetch() (reqres.SecretFetchResponse, error) {
 	)
 	if err != nil {
 		return reqres.SecretFetchResponse{}, errors.Wrap(
-			err, "Fetch: failed getting SVID Bundle from the SPIFFE Workloads API",
+			err, "Fetch: failed getting SVID Bundle from the SPIFFE Workload API",
 		)
 	}
 


### PR DESCRIPTION
# Associate The Same Random Secret to Multiple Workloads

## Description

This PR provides the ability to associate the same secrets to multiple workloads.

This is especially useful when the secret is randomly generated because otherwise we would provide two different random secrets to two different workloads.

## Changes

The `SecretUpsertRequest` uses a list of workload ids, instead of a single workload id.

```go
type SecretUpsertRequest struct {
	WorkloadId   string            `json:"key"`
	WorkloadIds  []string          `json:"keys"`
```

All the other codes have been refactored to consume a collection of workload IDs instead of a single one.

## Test Policy Compliance

- [x] I have added or updated unit tests for my changes.
- [x] I have included integration tests where applicable.
- [x] All new and existing tests pass successfully.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

- [x] I have made corresponding changes to the documentation (if applicable).
- [x] I have updated any relevant READMEs or wiki pages.

## Checklist

Before you submit this PR, please make sure:

- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project's license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project's license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
