### PR TITLE
🌟 enhancement(VSecM Sentinel): option to terminate early

### DIFF
--- a/core/env/sentinel.go
+++ b/core/env/sentinel.go
@@ -70,7 +70,7 @@ func InitCommandRunnerWaitIntervalForSentinel() time.Duration {
 func TerminateSentinelOnInitCommandConnectivityFailure() bool {
 	p := os.Getenv("VSECM_SENTINEL_TERMINATE_ON_INIT_COMMAND_CONNECTIVITY_FAILURE")
 	if p == "" {
-		p = "false"
+		return false
 	}
 	return p == "true"
 }
@@ -97,7 +97,7 @@ func OIDCProviderBaseUrlForSentinel() string {
 func SentinelEnableOIDCResourceServer() bool {
 	p := os.Getenv("VSECM_SENTINEL_ENABLE_OIDC_RESOURCE_SERVER")
 	if p == "" {
-		p = "false"
+		return false
 	}
 	return p == "true"
 }

--- a/core/env/sentinel.go
+++ b/core/env/sentinel.go
@@ -67,6 +67,14 @@ func InitCommandRunnerWaitIntervalForSentinel() time.Duration {
 	return time.Duration(i) * time.Millisecond
 }
 
+func TerminateSentinelOnInitCommandConnectivityFailure() bool {
+	p := os.Getenv("VSECM_SENTINEL_TERMINATE_ON_INIT_COMMAND_CONNECTIVITY_FAILURE")
+	if p == "" {
+		p = "false"
+	}
+	return p == "true"
+}
+
 // OIDCProviderBaseUrlForSentinel returns the prefix to be used for the names of secrets that
 // VSecM Safe stores, when it is configured to persist the secret in the Kubernetes
 // cluster as Kubernetes `Secret` objects.


### PR DESCRIPTION
# Option for Sentinel to Terminate Early Upon Failure

## Description

If an environment variable is set, this PR enables Sentinel to crash early if something unexpected happens during it `RunInitCommands()` stage.

This way, instead of keeping the container up and waiting for a stable connection, we kill it and let the cluster restart it and let it recheck.

This would be a more cloud native way of doing things.

## Changes

List the major changes you have made in bullet points:

- ./app/sentinel/background/initialization/run.go -> used env var.
- ./core/env/sentinel.go -> added env var.

## Test Policy Compliance

I am guilty as charged.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

Documentation will be done separately.

## Checklist

Before you submit this PR, please make sure:
- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project's license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project's license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
