### PR TITLE
✨ test(VSecM): increase test coverage from core/env

### DIFF
--- a/core/env/backoff_test.go
+++ b/core/env/backoff_test.go
@@ -9,3 +9,213 @@
 */
 
 package env
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestBackoffMaxRetries(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected int64
+	}{
+		{
+			name:     "Environment variable not set",
+			envValue: "",
+			expected: 10,
+		},
+		{
+			name:     "Environment variable set to valid value",
+			envValue: "5",
+			expected: 5,
+		},
+		{
+			name:     "Environment variable set to invalid value",
+			envValue: "invalid",
+			expected: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_BACKOFF_MAX_RETRIES", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_BACKOFF_MAX_RETRIES")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := BackoffMaxRetries()
+
+			if result != tt.expected {
+				t.Errorf("Expected %d, but got %d", tt.expected, result)
+			}
+
+			os.Unsetenv("VSECM_BACKOFF_MAX_RETRIES")
+		})
+	}
+}
+
+func TestBackoffDelay(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected time.Duration
+	}{
+		{
+			name:     "Environment variable not set",
+			envValue: "",
+			expected: 1000 * time.Millisecond,
+		},
+		{
+			name:     "Environment variable set to valid value",
+			envValue: "500",
+			expected: 500 * time.Millisecond,
+		},
+		{
+			name:     "Environment variable set to invalid value",
+			envValue: "invalid",
+			expected: 1000 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_BACKOFF_DELAY", tt.envValue)
+				if err != nil {
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_BACKOFF_DELAY")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := BackoffDelay()
+
+			if result != tt.expected {
+				t.Errorf("Expected %v, but got %v", tt.expected, result)
+			}
+
+			os.Unsetenv("VSECM_BACKOFF_DELAY")
+		})
+	}
+}
+
+func TestBackoffMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "Environment variable not set",
+			envValue: "",
+			expected: "exponential",
+		},
+		{
+			name:     "Environment variable set to exponential",
+			envValue: "exponential",
+			expected: "exponential",
+		},
+		{
+			name:     "Environment variable set to linear",
+			envValue: "linear",
+			expected: "linear",
+		},
+		{
+			name:     "Environment variable set to invalid value",
+			envValue: "invalid",
+			expected: "linear",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_BACKOFF_MODE", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_BACKOFF_MODE")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := BackoffMode()
+
+			if result != tt.expected {
+				t.Errorf("Expected %s, but got %s", tt.expected, result)
+			}
+
+			os.Unsetenv("VSECM_BACKOFF_MODE")
+		})
+	}
+}
+
+func TestBackoffMaxDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected time.Duration
+	}{
+		{
+			name:     "Environment variable not set",
+			envValue: "",
+			expected: 30000 * time.Millisecond,
+		},
+		{
+			name:     "Environment variable set to valid value",
+			envValue: "15000",
+			expected: 15000 * time.Millisecond,
+		},
+		{
+			name:     "Environment variable set to invalid value",
+			envValue: "invalid",
+			expected: 30000 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_BACKOFF_MAX_DURATION", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_BACKOFF_MAX_DURATION")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := BackoffMaxDuration()
+
+			if result != tt.expected {
+				t.Errorf("Expected %v, but got %v", tt.expected, result)
+			}
+
+			os.Unsetenv("VSECM_BACKOFF_MAX_DURATION")
+		})
+	}
+}

--- a/core/env/keygen_test.go
+++ b/core/env/keygen_test.go
@@ -9,3 +9,149 @@
 */
 
 package env
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRootKeyPathForKeyGen(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "Environment variable not set",
+			envValue: "",
+			expected: "/opt/vsecm/keys.txt",
+		},
+		{
+			name:     "Environment variable set to non-empty value",
+			envValue: "/custom/key/path",
+			expected: "/custom/key/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_KEYGEN_ROOT_KEY_PATH", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_KEYGEN_ROOT_KEY_PATH")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := RootKeyPathForKeyGen()
+
+			if result != tt.expected {
+				t.Errorf("Expected %s, but got %s", tt.expected, result)
+			}
+
+			os.Unsetenv("VSECM_KEYGEN_ROOT_KEY_PATH")
+		})
+	}
+}
+
+func TestExportedSecretPathForKeyGen(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "Environment variable not set",
+			envValue: "",
+			expected: "/opt/vsecm/secrets.json",
+		},
+		{
+			name:     "Environment variable set to non-empty value",
+			envValue: "/custom/secrets/path",
+			expected: "/custom/secrets/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_KEYGEN_EXPORTED_SECRET_PATH", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_KEYGEN_EXPORTED_SECRET_PATH")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := ExportedSecretPathForKeyGen()
+
+			if result != tt.expected {
+				t.Errorf("Expected %s, but got %s", tt.expected, result)
+			}
+
+			os.Unsetenv("VSECM_KEYGEN_EXPORTED_SECRET_PATH")
+		})
+	}
+}
+
+func TestKeyGenDecrypt(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected bool
+	}{
+		{
+			name:     "Environment variable not set",
+			envValue: "",
+			expected: false,
+		},
+		{
+			name:     "Environment variable set to true",
+			envValue: "true",
+			expected: true,
+		},
+		{
+			name:     "Environment variable set to false",
+			envValue: "false",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_KEYGEN_DECRYPT", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_KEYGEN_DECRYPT")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := KeyGenDecrypt()
+
+			if result != tt.expected {
+				t.Errorf("Expected %v, but got %v", tt.expected, result)
+			}
+
+			// Clean up
+			os.Unsetenv("VSECM_KEYGEN_DECRYPT")
+		})
+	}
+}

--- a/core/env/secret_test.go
+++ b/core/env/secret_test.go
@@ -9,3 +9,118 @@
 */
 
 package env
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSecretGenerationPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "ENV not set",
+			envValue: "",
+			expected: "gen:",
+		},
+		{
+			name:     "ENV set to non-empty value",
+			envValue: "custom:",
+			expected: "custom:",
+		},
+		{
+			name:     "ENV set to empty string",
+			envValue: "",
+			expected: "gen:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_SENTINEL_SECRET_GENERATION_PREFIX", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_SENTINEL_SECRET_GENERATION_PREFIX")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := SecretGenerationPrefix()
+
+			if result != tt.expected {
+				t.Errorf("Expected %s, but got %s", tt.expected, result)
+			}
+
+			err := os.Unsetenv("VSECM_SENTINEL_SECRET_GENERATION_PREFIX")
+			if err != nil {
+				t.Errorf("Error unsetting environment variable: %v", err)
+				return
+			}
+		})
+	}
+}
+
+func TestStoreWorkloadAsK8sSecretPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "ENV not set",
+			envValue: "",
+			expected: "k8s:",
+		},
+		{
+			name:     "ENV set to non-empty value",
+			envValue: "custom:",
+			expected: "custom:",
+		},
+		{
+			name:     "ENV set to empty string",
+			envValue: "",
+			expected: "k8s:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_SAFE_STORE_WORKLOAD_SECRET_AS_K8S_SECRET_PREFIX", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_SAFE_STORE_WORKLOAD_SECRET_AS_K8S_SECRET_PREFIX")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := StoreWorkloadAsK8sSecretPrefix()
+
+			if result != tt.expected {
+				t.Errorf("Expected %s, but got %s", tt.expected, result)
+			}
+
+			err := os.Unsetenv("VSECM_SAFE_STORE_WORKLOAD_SECRET_AS_K8S_SECRET_PREFIX")
+			if err != nil {
+				t.Errorf("Error unsetting environment variable: %v", err)
+				return
+			}
+		})
+	}
+}

--- a/core/env/sentinel_test.go
+++ b/core/env/sentinel_test.go
@@ -9,3 +9,249 @@
 */
 
 package env
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestInitCommandPathForSentinel(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "env not set",
+			envValue: "",
+			expected: "/opt/vsecm-sentinel/init/data",
+		},
+		{
+			name:     "env set to non-empty value",
+			envValue: "/custom/path",
+			expected: "/custom/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_SENTINEL_INIT_COMMAND_PATH", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_SENTINEL_INIT_COMMAND_PATH")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := InitCommandPathForSentinel()
+
+			if result != tt.expected {
+				t.Errorf("Expected %s, but got %s", tt.expected, result)
+			}
+
+			os.Unsetenv("VSECM_SENTINEL_INIT_COMMAND_PATH")
+		})
+	}
+}
+
+func TestInitCommandRunnerWaitBeforeExecIntervalForSentinel(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected time.Duration
+	}{
+		{
+			name:     "Environment variable not set",
+			envValue: "",
+			expected: 0 * time.Millisecond,
+		},
+		{
+			name:     "Environment variable set to valid integer",
+			envValue: "100",
+			expected: 100 * time.Millisecond,
+		},
+		{
+			name:     "Environment variable set to invalid integer",
+			envValue: "invalid",
+			expected: 0 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_SENTINEL_INIT_COMMAND_WAIT_BEFORE_EXEC", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_SENTINEL_INIT_COMMAND_WAIT_BEFORE_EXEC")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := InitCommandRunnerWaitBeforeExecIntervalForSentinel()
+
+			if result != tt.expected {
+				t.Errorf("Expected %v, but got %v", tt.expected, result)
+			}
+
+			os.Unsetenv("VSECM_SENTINEL_INIT_COMMAND_WAIT_BEFORE_EXEC")
+		})
+	}
+}
+
+func TestInitCommandRunnerWaitIntervalBeforeInitComplete(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected time.Duration
+	}{
+		{
+			name:     "Environment variable not set",
+			envValue: "",
+			expected: 0 * time.Millisecond,
+		},
+		{
+			name:     "Environment variable set to valid integer",
+			envValue: "100",
+			expected: 100 * time.Millisecond,
+		},
+		{
+			name:     "Environment variable set to invalid integer",
+			envValue: "invalid",
+			expected: 0 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_SENTINEL_INIT_COMMAND_WAIT_AFTER_INIT_COMPLETE", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_SENTINEL_INIT_COMMAND_WAIT_AFTER_INIT_COMPLETE")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := InitCommandRunnerWaitIntervalBeforeInitComplete()
+
+			if result != tt.expected {
+				t.Errorf("Expected %v, but got %v", tt.expected, result)
+			}
+
+			os.Unsetenv("VSECM_SENTINEL_INIT_COMMAND_WAIT_AFTER_INIT_COMPLETE")
+		})
+	}
+}
+
+func TestOIDCProviderBaseUrlForSentinel(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "Environment variable not set",
+			envValue: "",
+			expected: "",
+		},
+		{
+			name:     "Environment variable set to non-empty value",
+			envValue: "https://oidc.example.com",
+			expected: "https://oidc.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_SENTINEL_OIDC_PROVIDER_BASE_URL", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_SENTINEL_OIDC_PROVIDER_BASE_URL")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := OIDCProviderBaseUrlForSentinel()
+
+			if result != tt.expected {
+				t.Errorf("Expected %s, but got %s", tt.expected, result)
+			}
+
+			os.Unsetenv("VSECM_SENTINEL_OIDC_PROVIDER_BASE_URL")
+		})
+	}
+}
+
+func TestSentinelEnableOIDCResourceServer(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected bool
+	}{
+		{
+			name:     "Environment variable not set",
+			envValue: "",
+			expected: false,
+		},
+		{
+			name:     "Environment variable set to true",
+			envValue: "true",
+			expected: true,
+		},
+		{
+			name:     "Environment variable set to false",
+			envValue: "false",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				err := os.Setenv("VSECM_SENTINEL_ENABLE_OIDC_RESOURCE_SERVER", tt.envValue)
+				if err != nil {
+					t.Errorf("Error setting environment variable: %v", err)
+					return
+				}
+			} else {
+				err := os.Unsetenv("VSECM_SENTINEL_ENABLE_OIDC_RESOURCE_SERVER")
+				if err != nil {
+					t.Errorf("Error unsetting environment variable: %v", err)
+					return
+				}
+			}
+
+			result := SentinelEnableOIDCResourceServer()
+
+			if result != tt.expected {
+				t.Errorf("Expected %v, but got %v", tt.expected, result)
+			}
+
+			os.Unsetenv("VSECM_SENTINEL_ENABLE_OIDC_RESOURCE_SERVER")
+		})
+	}
+}

--- a/makefiles/Test.mk
+++ b/makefiles/Test.mk
@@ -28,7 +28,10 @@ cover:
     	echo "Test coverage is less than $(threshold)"; \
 		exit 0; \
 	fi
-	@echo "Test coverage is greater than $(threshold)"
+	if [ "$$coverage" != "" ] && awk 'BEGIN{exit !('"$$coverage"'>=$(threshold))}'; then \
+		echo "Test coverage is greater than $(threshold)"; \
+		exit 0; \
+	fi
 	@rm -f $(coverage_file)
 
 #


### PR DESCRIPTION
# Increase test coverage from core/env and fix test-coverage makefile

## Description

Test coverage up to  %15.2 from %13.2

## Changes

- Add Test for core/env/secret_test.go #896
- Add Test for core/env/sentinel_test.go #897
- Add Test for core/env/keygen_test.go #895
- Add Test for core/env/backoff_test.go #894
- Fix coverage test makefile code

## Test Policy Compliance

- [x] I have added or updated unit tests for my changes.
- [ ] I have included integration tests where applicable.
- [x] All new and existing tests pass successfully.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

- [x] I have made corresponding changes to the documentation (if applicable).
- [x] I have updated any relevant READMEs or wiki pages.

## Additional Comments

Include any additional comments or context about the PR here.

## Checklist

Before you submit this PR, please make sure:
- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project's license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project's license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
