### PR TITLE
Documentation update and multi-node minikube

### DIFF
--- a/docs/content/documentation/development/dev-env.md
+++ b/docs/content/documentation/development/dev-env.md
@@ -232,6 +232,15 @@ curl localhost:50565/v2/_catalog
 
 ```
 
+> **Do You Need Multiple Nodes**
+>
+> If you are using Minikube Docker driver, you can configure it to start
+> with multiple nodes. This can be useful if you want to test an
+> advanced scenario where more than one **SPIRE Agent** may be required.
+> 
+> For that, set up the `VSECM_MINIKUBE_NODE_COUNT` variable to the number
+> of Kubernetes worker nodes you wish to use in your development environment.
+
 There are two issues here:
 
 * First, all the local development scripts assume port 5000 as the repository port;

--- a/docs/content/documentation/use-cases/init-container.md
+++ b/docs/content/documentation/use-cases/init-container.md
@@ -214,15 +214,37 @@ Here are the meanings of the parameters in the above command:
 * `-w` is the name of the workload.
 * `-n` identifies the namespace of the Kubernetes `Secret`.
 * `-s` is the actual value of the secret.
+* `-t` is the template that will transform this secret to the `data` portion 
+  of the Kubernetes `Secret`.
 
 ### Initializing the Workload
 
 We have created a Kubernetes `Secret`.
 
-TODO: the workflow has changed, you will need to register a vsecm secret
-targeted for the workload to trigger its init container.
+Next, we will register a dummy secret to the workload using **VSecM Sentinel**.
+This will make the init container exit successfully and let the main container
+of the workload initialize.
 
-Now let's check if our pod has initialized:
+```bash
+kubectl exec "$SENTINEL" -n vsecm-system -- safe \
+  -w "example" \
+  -s "trigger" \
+  -n default
+```
+
+> **Why Do We Need a Dummy Secret?**
+> 
+> This use case assumes that we do not have access to the source code of the
+> workload. The workload is designed to consume secrets as environment variables.
+> 
+> If we had access to the source code, we could have modified it to consume
+> secrets from [**VSecM SDK**][vsecm-sdk] or [**VSecM Sidecar**][vsecm-sidecar].
+> In that case, we would not need to register a dummy secret to the workload.
+
+[vsecm-sdk]: @/documentation/use-cases/vsecm-sdk.md
+[vsecm-sidecar]: @/documentation/use-cases/sidecar.md
+
+Now, let's check if our pod has initialized:
 
 ```bash 
 kubectl get po

--- a/docs/content/timeline/changelog.md
+++ b/docs/content/timeline/changelog.md
@@ -17,6 +17,9 @@ weight = 11
 
 * Added ability to have regex-based SPIFFE ID matchers.
 * Enabled stricter validation on SPIFFE IDs to reduce configuration errors.
+* Added ability to optionailly use multiple worker nodes for the development
+  clusters.
+* Documentation updates.
 
 ## [0.25.3] - 2024-05-17
 

--- a/hack/minikube-start.sh
+++ b/hack/minikube-start.sh
@@ -20,6 +20,7 @@ minikube start \
     --extra-config=apiserver.authorization-mode=Node,RBAC \
     --memory="$MEMORY" \
     --cpus="$CPU" \
+    --nodes="$NODES" \
     --insecure-registry "10.0.0.0/24"
 
 echo "waiting 10 secs before enabling registry"

--- a/makefiles/VSecMDeploy.mk
+++ b/makefiles/VSecMDeploy.mk
@@ -17,6 +17,7 @@ MANIFESTS_LOCAL_PATH="${MANIFESTS_BASE_PATH}/local"
 MANIFESTS_EKS_PATH="${MANIFESTS_BASE_PATH}/eks"
 MANIFESTS_REMOTE_PATH="${MANIFESTS_BASE_PATH}/remote"
 CPU ?= $(or $(VSECM_MINIKUBE_CPU_COUNT),2)
+NODES ?= $(or $(VSECM_MINIKUBE_NODE_COUNT),1)
 MEMORY ?= $(or $(VSECM_MINIKUBE_MEMORY),4096)
 
 # Removes the former VSecM deployment without entirely destroying the cluster.
@@ -28,7 +29,7 @@ k8s-delete:
 	./hack/minikube-delete.sh
 # Brings up a fresh Minikube cluster.
 k8s-start:
-	@CPU=$(CPU) MEMORY=$(MEMORY) ./hack/minikube-start.sh
+	@NODES=$(NODES) @CPU=$(CPU) MEMORY=$(MEMORY) ./hack/minikube-start.sh
 
 deploy-spire-crds:
 	kubectl apply -f ${MANIFESTS_BASE_PATH}/crds


### PR DESCRIPTION
This PR updates a use-case documentation based on the recent changes.

It also adds the ability to run integration tests in a multi-node Minikube cluster.