### PR TITLE
remove default spiffeids.

### DIFF
--- a/helm-charts/0.26.2/charts/spire/templates/clusterspiffeid-spire-server-spire-default.yaml
+++ b/helm-charts/0.26.2/charts/spire/templates/clusterspiffeid-spire-server-spire-default.yaml
@@ -8,6 +8,7 @@
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
+{{- if .Values.enableSpireMintedDefaultClusterSpiffeIds }}
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
@@ -23,4 +24,4 @@ spec:
           - spire-server
           - spire-system
           - vsecm-system
-          - default
+{{- end }}

--- a/helm-charts/0.26.2/charts/spire/values.yaml
+++ b/helm-charts/0.26.2/charts/spire/values.yaml
@@ -40,6 +40,20 @@ experimental:
   # performance. It is set to `false` by default, just in case.
   eventsBasedCache: false
 
+# -- SPIRE assigns a default Cluster SPIFFE ID to all workloads in the
+# cluster. The SPIFFEID SPIRE assigns by default is not aligned with the
+# SPIFFE ID format that VSecM Safe expects. Also, you might not want
+# SPIRE to assign SPIFFE IDs to every single workload you have in your
+# cluster if you are not using SPIRE to attest those workloads. Therefore,
+# this option is set to false by default.
+#
+# If you set this to true, make sure you update `safeSpiffeIdTemplate`
+# `sentinelSpiffeIdTemplate`, `keystoneSpiffeIdTemplate`,
+# `workloadNameRegExp`, `workloadSpiffeIdPrefix`, `safeSpiffeIdPrefix`,
+# `sentinelSpiffeIdPrefix` and other relevant configurations to match
+# with what SPIRE assigns.
+enableSpireMintedDefaultClusterSpiffeIds: false
+
 # -- SPIRE Agent settings.
 spireAgent:
   # -- The corresponding SPIRE Agent socket directory on the host.

--- a/k8s/0.26.2/spire.yaml
+++ b/k8s/0.26.2/spire.yaml
@@ -1180,17 +1180,6 @@ spec:
           requests:
             storage: 1Gi
 ---
-# Source: vsecm/charts/spire/templates/openshift-security-context-constraints.yaml
-# /*
-# |    Protect your secrets, protect your sensitive data.
-# :    Explore VMware Secrets Manager docs at https://vsecm.com/
-# </
-# <>/  keep your secrets... secret
-# >/
-# <>/' Copyright 2023-present VMware Secrets Manager contributors.
-# >/'  SPDX-License-Identifier: BSD-2-Clause
-# */
----
 # Source: vsecm/charts/spire/templates/clusterspiffeid-spire-server-spire-default.yaml
 # /*
 # |    Protect your secrets, protect your sensitive data.
@@ -1201,23 +1190,17 @@ spec:
 # <>/' Copyright 2023-present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
-
-apiVersion: spire.spiffe.io/v1alpha1
-kind: ClusterSPIFFEID
-metadata:
-  name: spire-server-spire-default
-spec:
-  className: "vsecm"
-  spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
-  namespaceSelector:
-    matchExpressions:
-      - key: kubernetes.io/metadata.name
-        operator: NotIn
-        values:
-          - spire-server
-          - spire-system
-          - vsecm-system
-          - default
+---
+# Source: vsecm/charts/spire/templates/openshift-security-context-constraints.yaml
+# /*
+# |    Protect your secrets, protect your sensitive data.
+# :    Explore VMware Secrets Manager docs at https://vsecm.com/
+# </
+# <>/  keep your secrets... secret
+# >/
+# <>/' Copyright 2023-present VMware Secrets Manager contributors.
+# >/'  SPDX-License-Identifier: BSD-2-Clause
+# */
 ---
 # Source: vsecm/charts/spire/templates/clusterspiffeid-spire-server-spire-test-keys.yaml
 # /*


### PR DESCRIPTION
This PR removes the default SPIFFEID assignment from SPIRE charts (it can be enabled, but it is disabled by default). This way, VSecM-minted SPIFFEIDs will not conflict with SPIRE-minted ones.