### PR TITLE
🛡️ security(VSecM): remove printAdditionalDetails from envInfo

### DIFF
--- a/core/log/std/augment.go
+++ b/core/log/std/augment.go
@@ -12,12 +12,6 @@ package std
 
 import (
 	"os"
-	"runtime"
-	"strings"
-
-	"github.com/vmware-tanzu/secrets-manager/core/constants/key"
-	"github.com/vmware-tanzu/secrets-manager/core/env"
-	"github.com/vmware-tanzu/secrets-manager/core/log/level"
 )
 
 func updateInfoWithExpectedEnvVars(
@@ -34,12 +28,4 @@ func updateInfoWithExpectedEnvVars(
 	}
 
 	return nf
-}
-
-func appendAdditionalDetails(info map[string]string) {
-	if env.LogLevel() >= int(level.Trace) {
-		info[key.EnvVars] = strings.Join(envVars(), ", ")
-	}
-
-	info[key.GoVersion] = runtime.Version()
 }

--- a/core/log/std/envinfo.go
+++ b/core/log/std/envinfo.go
@@ -20,7 +20,5 @@ func PrintEnvironmentInfo(id *string, envVarsToExpect []string) {
 		WarnLn(id, "Environment variable '"+v+"' not found")
 	}
 
-	appendAdditionalDetails(info)
-
 	printFormattedInfo(id, info)
 }


### PR DESCRIPTION
## 🛡️ security(VSecM): remove printAdditionalDetails from envInfo

printAdditionalDetails is able to print arbitrary information about all environment variables. Giving too much info can be used as an aid to a possible attack vector; especially if environment is misconfigured.

Removing this from the source code.

If one wants environment information, they can always `kubectl describe` the associated Pod.

Note that we still display information like version number, and log level, etc.