### PR TITLE
🐛 fix(VSecM Keygen): regression: keygen was not decrypting secrets

### DIFF
--- a/app/keygen/cmd/main.go
+++ b/app/keygen/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware-tanzu/secrets-manager/core/crypto"
 	"github.com/vmware-tanzu/secrets-manager/core/env"
 	log "github.com/vmware-tanzu/secrets-manager/core/log/std"
+	"os"
 )
 
 func main() {
@@ -27,6 +28,27 @@ func main() {
 		string(e.VSecMLogLevel),
 		string(e.VSecMKeygenDecrypt),
 	})
+
+	// This is a Kubernetes Secret, mounted as a file.
+	keyPath := env.RootKeyPathForKeyGen()
+
+	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+		log.FatalLn(&id,
+			"CreateRootKey: Secret key not mounted at", keyPath)
+		return
+	}
+
+	data, err := os.ReadFile(keyPath)
+	if err != nil {
+		log.FatalLn(&id,
+			"CreateRootKey: Error reading file:", err.Error())
+		return
+	}
+
+	// Root key needs to be committed to memory for VSecM Keygen to be able
+	// to decrypt the secrets.
+	secret := string(data)
+	crypto.SetRootKeyInMemory(secret)
 
 	if env.KeyGenDecrypt() {
 		internal.PrintDecryptedKeys()

--- a/app/keygen/cmd/main.go
+++ b/app/keygen/cmd/main.go
@@ -29,28 +29,28 @@ func main() {
 		string(e.VSecMKeygenDecrypt),
 	})
 
-	// This is a Kubernetes Secret, mounted as a file.
-	keyPath := env.RootKeyPathForKeyGen()
-
-	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
-		log.FatalLn(&id,
-			"CreateRootKey: Secret key not mounted at", keyPath)
-		return
-	}
-
-	data, err := os.ReadFile(keyPath)
-	if err != nil {
-		log.FatalLn(&id,
-			"CreateRootKey: Error reading file:", err.Error())
-		return
-	}
-
-	// Root key needs to be committed to memory for VSecM Keygen to be able
-	// to decrypt the secrets.
-	secret := string(data)
-	crypto.SetRootKeyInMemory(secret)
-
 	if env.KeyGenDecrypt() {
+		// This is a Kubernetes Secret, mounted as a file.
+		keyPath := env.RootKeyPathForKeyGen()
+
+		if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+			log.FatalLn(&id,
+				"CreateRootKey: Secret key not mounted at", keyPath)
+			return
+		}
+
+		data, err := os.ReadFile(keyPath)
+		if err != nil {
+			log.FatalLn(&id,
+				"CreateRootKey: Error reading file:", err.Error())
+			return
+		}
+
+		// Root key needs to be committed to memory for VSecM Keygen to be able
+		// to decrypt the secrets.
+		secret := string(data)
+		crypto.SetRootKeyInMemory(secret)
+
 		internal.PrintDecryptedKeys()
 		return
 	}


### PR DESCRIPTION
## About

Due to a missing root key getter, keygen could not decrypt secrets. 

This patch fixes it.

## Changes

- in the entry point `./cmd/main.go` of VSecM KeyGen, we now read the secret keys from the saved file and storing them in memory before starting the secret decryption process.

## Test Policy Compliance

- [ ] I have added or updated unit tests for my changes.
- [ ] I have included integration tests where applicable.
- [x] All new and existing tests pass successfully.

## Code Quality

- [x] I have followed the coding standards for this project.
- [x] I have performed a self-review of my code.
- [x] My code is well-commented, particularly in areas that may be difficult 
      to understand.

## Documentation

- [x] I have made corresponding changes to the documentation (if applicable).
- [x] I have updated any relevant READMEs or wiki pages.

## Checklist

Before you submit this PR, please make sure:
- [x] You have read [the contributing guidelines][contributing] and 
      *especially* the [test policy][test-policy].
- [x] You have thoroughly tested your changes.
- [x] You have followed all the contributing guidelines for this project.
- [x] You understand and agree that your contributions will be publicly available 
  under the project's license.

[contributing]: https://vsecm.com/docs/contributing/
[test-policy]: https://vsecm.com/docs/contributing/#add-tests-for-new-features

*By submitting this pull request, you confirm that my contribution is made under 
the terms of the project's license and that you have the authority to grant 
these rights.*

---

Thank you for your contribution to [**VMware Secrets Manager**](https://vsecm.com)
🐢⚡️!
