### PR TITLE
🌟 enhancement(VSecM): pointed example images to upstream

### DIFF
--- a/examples/multiple_secrets/k8s/image-override.yaml
+++ b/examples/multiple_secrets/k8s/image-override.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: main
         # Change this, if you want to use a different image:
-        image: localhost:5000/example-multiple-secrets:0.27.1
+        image: vsecm/example-multiple-secrets:latest
         env:
           - name: VSECM_LOG_LEVEL
             value: "7"

--- a/examples/using_init_container/k8s/image-override.yaml
+++ b/examples/using_init_container/k8s/image-override.yaml
@@ -19,8 +19,8 @@ spec:
       containers:
       - name: main
         # Change this, if you want to use a different image:
-        image: localhost:5000/example-using-init-container:0.27.1
+        image: vsecm/example-using-init-container:latest
       initContainers:
       - name: init-container
         # Change this, if you want to use a different image:
-        image: localhost:5000/vsecm-ist-init-container:0.27.1
+        image: vsecm/vsecm-ist-init-container:latest

--- a/examples/using_sdk_go/k8s/image-override.yaml
+++ b/examples/using_sdk_go/k8s/image-override.yaml
@@ -19,4 +19,4 @@ spec:
       containers:
       - name: main
         # Change this, if you want to use a different image
-        image: localhost:5000/example-using-sdk-go:0.27.1
+        image: vsecm/example-using-sdk-go:latest

--- a/examples/using_sidecar/k8s/image-override.yaml
+++ b/examples/using_sidecar/k8s/image-override.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: main
         # Change this, if you want to use a different image
-        image: localhost:5000/example-using-sidecar:0.27.1
+        image: vsecm/example-using-sidecar:latest
       - name: sidecar
         # Change this, if you want to use a different image
-        image: localhost:5000/vsecm-ist-sidecar:0.27.1
+        image: vsecm/vsecm-ist-sidecar:latest

--- a/examples/using_vsecm_inspector/Deployment.yaml
+++ b/examples/using_vsecm_inspector/Deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: vsecm-inspector
       containers:
         - name: main
-          image: localhost:5000/vsecm-inspector:latest
+          image: vsecm/vsecm-inspector:latest
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /spire-agent-socket


### PR DESCRIPTION
update example image overrides to refer from the "latest" tag on upstream instead of "localhost:5000". This will allow people to follow the use cases and other examples in the documentation easier as they won't have to build the project from source and also they won't need to update the version numbers.

Since the version numbers in the repository often points to a future version that has not been published yet, trying to install them without updating the image-overrides was causing "image not found" errors. This PR addresses that by always pointing the example images to the `latest` upsream version.

Since these examples often do not change and are mature enough, it does not quite matter where you pull them from as long as you can download and install them.

This PR does not change other product images and image overrides, it only affect the image overrides under the `./examples` folder.