### PR TITLE
🐛 fix(VSecM): fix logic error in example workload

### DIFF
--- a/examples/using_init_container/main.go
+++ b/examples/using_init_container/main.go
@@ -39,9 +39,11 @@ func main() {
 
 		fmt.Println("")
 
+		// Print the contents of the mounted file, if you
+		// can read it.
 		path := "/opt/vsecm/secrets.json"
 		data, err := os.ReadFile(path)
-		if err != nil {
+		if err == nil {
 			fmt.Println("File content: ", string(data))
 		}
 

--- a/examples/using_init_container_with_k8s_secrets/k8s/Deployment.yaml
+++ b/examples/using_init_container_with_k8s_secrets/k8s/Deployment.yaml
@@ -135,3 +135,8 @@ spec:
         csi:
           driver: "csi.spiffe.io"
           readOnly: true
+      # A memory-backed volume is recommended (but not required) to keep
+      # the secrets. The secrets can be stored in any kind of volume.
+      - name: vsecm-secrets-volume
+        emptyDir:
+          medium: Memory


### PR DESCRIPTION
* deployment was missing a volume mount.
* there was a logic error in the source code.
