### PR TITLE
🐛 fix(VSecM Helm Charts): SPIRE Server was crashing if not persistent

### DIFF
--- a/helm-charts/0.27.1/charts/spire/templates/statefulset-spire-server.yaml
+++ b/helm-charts/0.27.1/charts/spire/templates/statefulset-spire-server.yaml
@@ -113,13 +113,9 @@ spec:
             - name: spire-config
               mountPath: {{ .Values.spireServer.configDir }}
               readOnly: true
-
-{{- if .Values.data.persistent }}
             - name: spire-data
               mountPath: {{ .Values.spireServer.dataDir }}
               readOnly: false
-{{- end }}
-
             - name: server-tmp
               mountPath: /tmp
               readOnly: false

--- a/k8s/0.27.1/spire.yaml
+++ b/k8s/0.27.1/spire.yaml
@@ -1104,7 +1104,6 @@ spec:
             - name: spire-data
               mountPath: /run/spire/data
               readOnly: false
-
             - name: server-tmp
               mountPath: /tmp
               readOnly: false


### PR DESCRIPTION
SPIRE server was crashing in non-persistent mode. This patch fixes it.
