### PR TITLE
v0.27.2

### DIFF
--- a/docs/content/timeline/changelog.md
+++ b/docs/content/timeline/changelog.md
@@ -19,6 +19,8 @@ weight = 11
 * Updated some of the Asciinema screen recordings of the use cases.
 * Other documentation updates.
 * Minor code fixes and enhancements.
+* Added missing imagePullSecrets to SPIFFE CSI Driver helm template of the
+  VSecM Helm charts.
 
 ## [0.27.1] - 2024-09-13
 

--- a/helm-charts/0.27.2/charts/spire/templates/daemonset-spire-spiffe-csi-driver.yaml
+++ b/helm-charts/0.27.2/charts/spire/templates/daemonset-spire-spiffe-csi-driver.yaml
@@ -34,6 +34,11 @@ spec:
         app.kubernetes.io/name: spiffe-csi-driver
         app.kubernetes.io/instance: spire
     spec:
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
+
       serviceAccountName: spire-spiffe-csi-driver
 
       priorityClassName: system-node-critical

--- a/k8s/0.27.2/spire.yaml
+++ b/k8s/0.27.2/spire.yaml
@@ -899,6 +899,7 @@ spec:
         app.kubernetes.io/name: spiffe-csi-driver
         app.kubernetes.io/instance: spire
     spec:
+
       serviceAccountName: spire-spiffe-csi-driver
 
       priorityClassName: system-node-critical


### PR DESCRIPTION
## v0.27.2

Added missing `imagePullSecrets` to the SPIFFE CSI Driver chart.