### PR TITLE
Helm Charts: Ability to opt out from namespace creation

### DIFF
--- a/docs/content/timeline/changelog.md
+++ b/docs/content/timeline/changelog.md
@@ -15,7 +15,9 @@ weight = 11
 
 ## Recent Changes
 
-## [0.27.3] - 2024-09-30
+* Added helm charts the ability to optionally disable custom namespace generation.
+
+## [0.27.2] - 2024-09-30
 
 ### Added
 

--- a/helm-charts/0.27.3/charts/safe/templates/hook-preinstall-namespace.yaml
+++ b/helm-charts/0.27.3/charts/safe/templates/hook-preinstall-namespace.yaml
@@ -8,7 +8,9 @@
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
+{{- if .Values.global.preInstallVSecMNamespaces }}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.global.vsecm.namespace }}
+{{- end }}

--- a/helm-charts/0.27.3/charts/spire/templates/hook-preinstall-namespace-spire-server.yaml
+++ b/helm-charts/0.27.3/charts/spire/templates/hook-preinstall-namespace-spire-server.yaml
@@ -8,6 +8,7 @@
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
+{{- if .Values.global.preInstallSpireNamespaces }}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -16,8 +17,9 @@ metadata:
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged
-{{- if .Values.global.enableOpenShift }}
+  {{- if .Values.global.enableOpenShift }}
     security.openshift.io/scc.podSecurityLabelSync: "false"
-{{- end }}
+  {{- end }}
   annotations:
     "helm.sh/hook": pre-install
+{{- end }}

--- a/helm-charts/0.27.3/charts/spire/templates/hook-preinstall-namespace-spire-system.yaml
+++ b/helm-charts/0.27.3/charts/spire/templates/hook-preinstall-namespace-spire-system.yaml
@@ -8,6 +8,7 @@
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
 
+{{- if .Values.global.preInstallSpireNamespaces }}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -21,3 +22,4 @@ metadata:
 {{- end }}
   annotations:
     "helm.sh/hook": pre-install
+{{- end }}

--- a/helm-charts/0.27.3/values.yaml
+++ b/helm-charts/0.27.3/values.yaml
@@ -13,6 +13,16 @@ global:
   # using kapp to deploy the VSecM components. (ref: https://carvel.dev/kapp/)
   enableKAppAnnotations: false
 
+  # -- Set it to true to enable the pre-installation of the VSecM namespaces.
+  # If set to false, the VSecM namespaces will not be pre-installed; you will
+  # need to create a `vsecm-system` namespace manually.
+  preInstallVSecMNamespaces: true
+
+  # -- Set it to true to enable the pre-installation of the SPIRE namespaces.
+  # If set to false, the SPIRE namespaces will not be pre-installed; you will
+  # need to create `spire-system` and `spire-server` namespaces manually.
+  preInstallSpireNamespaces: true
+
   # -- Set it to true for OpenShift deployments. This will add necessary
   # annotations to the SPIRE components to make them work on OpenShift.
   enableOpenShift: false

--- a/k8s/0.27.3/eks/vsecm-distroless-fips.yaml
+++ b/k8s/0.27.3/eks/vsecm-distroless-fips.yaml
@@ -9,7 +9,6 @@
 # <>/' Copyright 2023-present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
-
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/k8s/0.27.3/eks/vsecm-distroless.yaml
+++ b/k8s/0.27.3/eks/vsecm-distroless.yaml
@@ -9,7 +9,6 @@
 # <>/' Copyright 2023-present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
-
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/k8s/0.27.3/local/vsecm-distroless-fips.yaml
+++ b/k8s/0.27.3/local/vsecm-distroless-fips.yaml
@@ -9,7 +9,6 @@
 # <>/' Copyright 2023-present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
-
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/k8s/0.27.3/local/vsecm-distroless.yaml
+++ b/k8s/0.27.3/local/vsecm-distroless.yaml
@@ -9,7 +9,6 @@
 # <>/' Copyright 2023-present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
-
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/k8s/0.27.3/remote/vsecm-distroless-fips.yaml
+++ b/k8s/0.27.3/remote/vsecm-distroless-fips.yaml
@@ -9,7 +9,6 @@
 # <>/' Copyright 2023-present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
-
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/k8s/0.27.3/remote/vsecm-distroless.yaml
+++ b/k8s/0.27.3/remote/vsecm-distroless.yaml
@@ -9,7 +9,6 @@
 # <>/' Copyright 2023-present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
-
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/k8s/0.27.3/spire.yaml
+++ b/k8s/0.27.3/spire.yaml
@@ -1289,7 +1289,6 @@ webhooks:
 # <>/' Copyright 2023-present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
-
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -1311,7 +1310,6 @@ metadata:
 # <>/' Copyright 2023-present VMware Secrets Manager contributors.
 # >/'  SPDX-License-Identifier: BSD-2-Clause
 # */
-
 apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
This PR gives the helm charts the ability to opt-out from creating `spire-server`, `spire-system` and `vsecm-system` namespace.

If the the namespace-creation is opted-out, then the operator will need to manually create these namespaces before installing the helm chart.