### PR TITLE
Remove Esteban from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,5 @@
 
 * @v0lkan           # Volkan Özçelik
 * @abhishek44sharma # Abhishek Sharma
-* @st96d045         # Esteban Serrano
 * @ats0stv          # Arun Thundyill Saseendran
 * @BulldromeQ       # Qi Hu

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,10 +20,6 @@ each with their responsibilities outlined.
 * **Abhishek Sharma** [@abhishek44sharma](https://github.com/abhishek44sharma)
   * Abhishek is a core contributor, working on various aspects of the project.
 
-* **Esteban Serrano** [@st96d045](https://github.com/st96d045)
-  * Esteban is a core contributor, focusing on integrating VSecM to various 
-    external components and hardening it for production use-cases.
-
 * **Arun Thundyill Saseendran** [@ats0stv](https://github.com/ats0stv)
   * Arun is a core contributor, assisting in feature development and workflow 
     automation.

--- a/docs/content/community/maintainers.md
+++ b/docs/content/community/maintainers.md
@@ -32,11 +32,6 @@ security, architecture decisions, and major feature developments.
 
 Abhishek is a core contributor, working on various aspects of the project.
 
-**Esteban Serrano** [@st96d045](https://github.com/st96d045)
-
-Esteban is a core contributor, focusing on integrating VSecM to various
-external components and hardening it for production use-cases.
-
 **Arun Thundyill Saseendran** [@ats0stv](https://github.com/ats0stv)
 
 Arun is a core contributor, assisting in feature development and workflow


### PR DESCRIPTION
Removing Esteban due to him not being a member of the VMware GitHub org anymore.

I want to use this opportunity to thank for all his contributions and being a great colleague, and friend.

VSecM wouldn't have been what it is without him.

Live long and prosper Esteban :vulcan_salute: .